### PR TITLE
Fix link case sensitivity in README_ZH.md

### DIFF
--- a/README_ZH.md
+++ b/README_ZH.md
@@ -26,7 +26,7 @@
 <div align="center">
 	
 <p>
-	<a href="README.md"><img src="https://img.shields.io/badge/English-1a1a2e?style=for-the-badge"></a>
+	<a href="readme.md"><img src="https://img.shields.io/badge/English-1a1a2e?style=for-the-badge"></a>
     <a href="README_ZH.md"><img src="https://img.shields.io/badge/中文版-1a1a2e?style=for-the-badge"></a>
 </p>
     <a href="#quick-start" style="text-decoration: none;">


### PR DESCRIPTION
On line 29 readme file was CAPS LOCK, however the file is low case