### PR TITLE
Abstract image and video generator behind RenderBackend

### DIFF
--- a/pipelines/idea2video_pipeline.py
+++ b/pipelines/idea2video_pipeline.py
@@ -9,8 +9,7 @@ import json
 from moviepy import VideoFileClip, concatenate_videoclips
 import yaml
 from langchain.chat_models import init_chat_model
-from utils.rate_limiter import RateLimiter
-import importlib
+from tools.render_backend import RenderBackend
 
 
 class Idea2VideoPipeline:
@@ -34,84 +33,17 @@ class Idea2VideoPipeline:
             image_generator=self.image_generator)
 
     @classmethod
-    def init_from_config(
-        cls,
-        config_path: str,
-    ):
+    def init_from_config(cls, config_path: str):
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        chat_model_args = config["chat_model"]["init_args"]
-        chat_model = init_chat_model(**chat_model_args)
-
-        # Create separate rate limiters for each service
-        chat_model_rpm = config.get("chat_model", {}).get("max_requests_per_minute", None)
-        chat_model_rpd = config.get("chat_model", {}).get("max_requests_per_day", None)
-        image_generator_rpm = config.get("image_generator", {}).get("max_requests_per_minute", None)
-        image_generator_rpd = config.get("image_generator", {}).get("max_requests_per_day", None)
-        video_generator_rpm = config.get("video_generator", {}).get("max_requests_per_minute", None)
-        video_generator_rpd = config.get("video_generator", {}).get("max_requests_per_day", None)
-
-        chat_model_rate_limiter = RateLimiter(
-            max_requests_per_minute=chat_model_rpm,
-            max_requests_per_day=chat_model_rpd
-        ) if (chat_model_rpm or chat_model_rpd) else None
-
-        image_rate_limiter = RateLimiter(
-            max_requests_per_minute=image_generator_rpm,
-            max_requests_per_day=image_generator_rpd
-        ) if (image_generator_rpm or image_generator_rpd) else None
-
-        video_rate_limiter = RateLimiter(
-            max_requests_per_minute=video_generator_rpm,
-            max_requests_per_day=video_generator_rpd
-        ) if (video_generator_rpm or video_generator_rpd) else None
-
-        # Display rate limiting configuration
-        if chat_model_rate_limiter:
-            limits = []
-            if chat_model_rpm:
-                limits.append(f"{chat_model_rpm} req/min")
-            if chat_model_rpd:
-                limits.append(f"{chat_model_rpd} req/day")
-            print(f"Chat model rate limiting: {', '.join(limits)}")
-
-        if image_rate_limiter:
-            limits = []
-            if image_generator_rpm:
-                limits.append(f"{image_generator_rpm} req/min")
-            if image_generator_rpd:
-                limits.append(f"{image_generator_rpd} req/day")
-            print(f"Image generator rate limiting: {', '.join(limits)}")
-
-        if video_rate_limiter:
-            limits = []
-            if video_generator_rpm:
-                limits.append(f"{video_generator_rpm} req/min")
-            if video_generator_rpd:
-                limits.append(f"{video_generator_rpd} req/day")
-            print(f"Video generator rate limiting: {', '.join(limits)}")
-
-        image_generator_cls_module, image_generator_cls_name = config["image_generator"]["class_path"].rsplit(
-            ".", 1)
-        image_generator_cls = getattr(importlib.import_module(
-            image_generator_cls_module), image_generator_cls_name)
-        image_generator_args = config["image_generator"]["init_args"]
-        image_generator_args["rate_limiter"] = image_rate_limiter
-        image_generator = image_generator_cls(**image_generator_args)
-
-        video_generator_cls_module, video_generator_cls_name = config["video_generator"]["class_path"].rsplit(
-            ".", 1)
-        video_generator_cls = getattr(importlib.import_module(
-            video_generator_cls_module), video_generator_cls_name)
-        video_generator_args = config["video_generator"]["init_args"]
-        video_generator_args["rate_limiter"] = video_rate_limiter
-        video_generator = video_generator_cls(**video_generator_args)
+        chat_model = init_chat_model(**config["chat_model"]["init_args"])
+        backend = RenderBackend.from_config(config)
 
         return cls(
             chat_model=chat_model,
-            image_generator=image_generator,
-            video_generator=video_generator,
+            image_generator=backend.image_generator,
+            video_generator=backend.video_generator,
             working_dir=config["working_dir"],
         )
 

--- a/pipelines/script2video_pipeline.py
+++ b/pipelines/script2video_pipeline.py
@@ -11,9 +11,7 @@ from agents import *
 import yaml
 from interfaces import *
 from langchain.chat_models import init_chat_model
-from utils.timer import Timer
-from utils.rate_limiter import RateLimiter
-import importlib
+from tools.render_backend import RenderBackend
 
 class Script2VideoPipeline:
 
@@ -47,80 +45,17 @@ class Script2VideoPipeline:
 
 
     @classmethod
-    def init_from_config(
-        cls,
-        config_path: str,
-    ):
+    def init_from_config(cls, config_path: str):
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        chat_model_args = config["chat_model"]["init_args"]
-        chat_model = init_chat_model(**chat_model_args)
-
-        # Create separate rate limiters for each service
-        chat_model_rpm = config.get("chat_model", {}).get("max_requests_per_minute", None)
-        chat_model_rpd = config.get("chat_model", {}).get("max_requests_per_day", None)
-        image_generator_rpm = config.get("image_generator", {}).get("max_requests_per_minute", None)
-        image_generator_rpd = config.get("image_generator", {}).get("max_requests_per_day", None)
-        video_generator_rpm = config.get("video_generator", {}).get("max_requests_per_minute", None)
-        video_generator_rpd = config.get("video_generator", {}).get("max_requests_per_day", None)
-
-        chat_model_rate_limiter = RateLimiter(
-            max_requests_per_minute=chat_model_rpm,
-            max_requests_per_day=chat_model_rpd
-        ) if (chat_model_rpm or chat_model_rpd) else None
-
-        image_rate_limiter = RateLimiter(
-            max_requests_per_minute=image_generator_rpm,
-            max_requests_per_day=image_generator_rpd
-        ) if (image_generator_rpm or image_generator_rpd) else None
-
-        video_rate_limiter = RateLimiter(
-            max_requests_per_minute=video_generator_rpm,
-            max_requests_per_day=video_generator_rpd
-        ) if (video_generator_rpm or video_generator_rpd) else None
-
-        # Display rate limiting configuration
-        if chat_model_rate_limiter:
-            limits = []
-            if chat_model_rpm:
-                limits.append(f"{chat_model_rpm} req/min")
-            if chat_model_rpd:
-                limits.append(f"{chat_model_rpd} req/day")
-            print(f"Chat model rate limiting: {', '.join(limits)}")
-
-        if image_rate_limiter:
-            limits = []
-            if image_generator_rpm:
-                limits.append(f"{image_generator_rpm} req/min")
-            if image_generator_rpd:
-                limits.append(f"{image_generator_rpd} req/day")
-            print(f"Image generator rate limiting: {', '.join(limits)}")
-
-        if video_rate_limiter:
-            limits = []
-            if video_generator_rpm:
-                limits.append(f"{video_generator_rpm} req/min")
-            if video_generator_rpd:
-                limits.append(f"{video_generator_rpd} req/day")
-            print(f"Video generator rate limiting: {', '.join(limits)}")
-
-        image_generator_cls_module, image_generator_cls_name = config["image_generator"]["class_path"].rsplit(".", 1)
-        image_generator_cls = getattr(importlib.import_module(image_generator_cls_module), image_generator_cls_name)
-        image_generator_args = config["image_generator"]["init_args"]
-        image_generator_args["rate_limiter"] = image_rate_limiter
-        image_generator = image_generator_cls(**image_generator_args)
-
-        video_generator_cls_module, video_generator_cls_name = config["video_generator"]["class_path"].rsplit(".", 1)
-        video_generator_cls = getattr(importlib.import_module(video_generator_cls_module), video_generator_cls_name)
-        video_generator_args = config["video_generator"]["init_args"]
-        video_generator_args["rate_limiter"] = video_rate_limiter
-        video_generator = video_generator_cls(**video_generator_args)
+        chat_model = init_chat_model(**config["chat_model"]["init_args"])
+        backend = RenderBackend.from_config(config)
 
         return cls(
             chat_model=chat_model,
-            image_generator=image_generator,
-            video_generator=video_generator,
+            image_generator=backend.image_generator,
+            video_generator=backend.video_generator,
             working_dir=config["working_dir"],
         )
 

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,20 +1,25 @@
-# image generator
+# rendering abstraction
+from .protocols import ImageGenerator, VideoGenerator
+from .render_backend import RenderBackend
+
+# image generators
 from .image_generator_doubao_seedream_yunwu_api import ImageGeneratorDoubaoSeedreamYunwuAPI
 from .image_generator_nanobanana_google_api import ImageGeneratorNanobananaGoogleAPI
 from .image_generator_nanobanana_yunwu_api import ImageGeneratorNanobananaYunwuAPI
 
-
 # reranker for rag
 from .reranker_bge_silicon_api import RerankerBgeSiliconapi
 
-
-# video generator
+# video generators
 from .video_generator_doubao_seedance_yunwu_api import VideoGeneratorDoubaoSeedanceYunwuAPI
 from .video_generator_veo_google_api import VideoGeneratorVeoGoogleAPI
 from .video_generator_veo_yunwu_api import VideoGeneratorVeoYunwuAPI
 
 
 __all__ = [
+    "ImageGenerator",
+    "VideoGenerator",
+    "RenderBackend",
     "ImageGeneratorDoubaoSeedreamYunwuAPI",
     "ImageGeneratorNanobananaGoogleAPI",
     "ImageGeneratorNanobananaYunwuAPI",

--- a/tools/protocols.py
+++ b/tools/protocols.py
@@ -1,0 +1,35 @@
+"""Structural typing contracts for rendering backends.
+
+Any class that exposes the right method signatures satisfies these
+protocols -- no inheritance required. Existing generators (Google,
+Yunwu/Doubao, Yunwu/Veo) are already compliant by duck typing.
+"""
+
+from typing import List, Protocol, runtime_checkable
+
+from interfaces.image_output import ImageOutput
+from interfaces.video_output import VideoOutput
+
+
+@runtime_checkable
+class ImageGenerator(Protocol):
+    """Generates a single image from a text prompt and optional reference images."""
+
+    async def generate_single_image(
+        self,
+        prompt: str,
+        reference_image_paths: List[str],
+        **kwargs,
+    ) -> ImageOutput: ...
+
+
+@runtime_checkable
+class VideoGenerator(Protocol):
+    """Generates a single video from a text prompt and optional reference images."""
+
+    async def generate_single_video(
+        self,
+        prompt: str,
+        reference_image_paths: List[str],
+        **kwargs,
+    ) -> VideoOutput: ...

--- a/tools/render_backend.py
+++ b/tools/render_backend.py
@@ -1,0 +1,62 @@
+"""RenderBackend: config-driven factory for image and video generators.
+
+Reads the ``image_generator`` and ``video_generator`` sections from a
+ViMax YAML config, instantiates the concrete classes via *class_path*,
+and wires up rate limiters.
+
+Usage::
+
+    backend = RenderBackend.from_config(config)
+    image = await backend.image_generator.generate_single_image(...)
+    video = await backend.video_generator.generate_single_video(...)
+"""
+
+import importlib
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from utils.rate_limiter import RateLimiter
+
+
+@dataclass
+class RenderBackend:
+    """Bundles an image generator and a video generator."""
+
+    image_generator: Any
+    video_generator: Any
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "RenderBackend":
+        """Build a RenderBackend from a parsed YAML config dict.
+
+        Rate limiters are created from ``max_requests_per_minute`` /
+        ``max_requests_per_day`` if present in each generator section.
+        """
+        img_cfg = config["image_generator"]
+        vid_cfg = config["video_generator"]
+
+        image_gen = _instantiate(img_cfg, _build_rate_limiter(img_cfg))
+        video_gen = _instantiate(vid_cfg, _build_rate_limiter(vid_cfg))
+
+        logging.info("RenderBackend: image=%s, video=%s",
+                     img_cfg["class_path"], vid_cfg["class_path"])
+
+        return cls(image_generator=image_gen, video_generator=video_gen)
+
+
+def _build_rate_limiter(section: Dict[str, Any]) -> RateLimiter | None:
+    rpm = section.get("max_requests_per_minute")
+    rpd = section.get("max_requests_per_day")
+    if rpm or rpd:
+        return RateLimiter(max_requests_per_minute=rpm, max_requests_per_day=rpd)
+    return None
+
+
+def _instantiate(section: Dict[str, Any], rate_limiter: RateLimiter | None) -> Any:
+    module_path, cls_name = section["class_path"].rsplit(".", 1)
+    cls = getattr(importlib.import_module(module_path), cls_name)
+    init_args = dict(section.get("init_args", {}))
+    if rate_limiter is not None:
+        init_args["rate_limiter"] = rate_limiter
+    return cls(**init_args)


### PR DESCRIPTION
## Summary

- Introduce `ImageGenerator` and `VideoGenerator` Protocol classes (`tools/protocols.py`) that formalize the duck-typed contract all existing generators already satisfy
- Add `RenderBackend` dataclass with `from_config()` factory (`tools/render_backend.py`) that handles class instantiation and rate limiter wiring from YAML config
- Replace duplicate ~70-line `init_from_config()` boilerplate in both `Script2VideoPipeline` and `Idea2VideoPipeline` with a 4-line `RenderBackend.from_config()` call

Zero changes to any existing provider code. All 3 backends (Google, Yunwu/Doubao, Yunwu/Veo) conform to the protocols by duck typing. Existing YAML configs work unchanged.

## Test plan

- [x] All imports verified (protocols, RenderBackend, both pipelines)
- [x] RenderBackend.from_config() tested with existing flat YAML configs
- [x] End-to-end pipeline run with Script2VideoPipeline.init_from_config()