### PR TITLE
Add MiniMax as first-class chat model provider

### DIFF
--- a/configs/idea2video_minimax.yaml
+++ b/configs/idea2video_minimax.yaml
@@ -1,0 +1,34 @@
+# Example configuration using MiniMax as the chat model provider.
+# MiniMax M2.7 is used via its OpenAI-compatible API.
+#
+# Set your API key below or export MINIMAX_API_KEY in the environment.
+# Available models:
+#   - MiniMax-M2.7           (latest, 1M context)
+#   - MiniMax-M2.7-highspeed (fast variant)
+#   - MiniMax-M2.5           (204K context)
+#   - MiniMax-M2.5-highspeed (fast variant)
+
+chat_model:
+  init_args:
+    model: MiniMax-M2.7
+    model_provider: minimax
+    api_key: <YOUR_MINIMAX_API_KEY>
+    # base_url is auto-resolved to https://api.minimax.io/v1
+  max_requests_per_minute: 500
+  max_requests_per_day: 2000
+
+image_generator:
+  class_path: tools.ImageGeneratorNanobananaGoogleAPI
+  init_args:
+    api_key: <YOUR_API_KEY>
+  max_requests_per_minute: 10
+  max_requests_per_day: 500
+
+video_generator:
+  class_path: tools.VideoGeneratorVeoGoogleAPI
+  init_args:
+    api_key: <YOUR_API_KEY>
+  max_requests_per_minute: 2
+  max_requests_per_day: 10
+
+working_dir: .working_dir/idea2video

--- a/configs/script2video_minimax.yaml
+++ b/configs/script2video_minimax.yaml
@@ -1,0 +1,34 @@
+# Example configuration using MiniMax as the chat model provider.
+# MiniMax M2.7 is used via its OpenAI-compatible API.
+#
+# Set your API key below or export MINIMAX_API_KEY in the environment.
+# Available models:
+#   - MiniMax-M2.7           (latest, 1M context)
+#   - MiniMax-M2.7-highspeed (fast variant)
+#   - MiniMax-M2.5           (204K context)
+#   - MiniMax-M2.5-highspeed (fast variant)
+
+chat_model:
+  init_args:
+    model: MiniMax-M2.7
+    model_provider: minimax
+    api_key: <YOUR_MINIMAX_API_KEY>
+    # base_url is auto-resolved to https://api.minimax.io/v1
+  max_requests_per_minute: null
+  max_requests_per_day: null
+
+image_generator:
+  class_path: tools.ImageGeneratorNanobananaGoogleAPI
+  init_args:
+    api_key: <YOUR_API_KEY>
+  max_requests_per_minute: 2
+  max_requests_per_day: 50
+
+video_generator:
+  class_path: tools.VideoGeneratorVeoGoogleAPI
+  init_args:
+    api_key: <YOUR_API_KEY>
+  max_requests_per_minute: 2
+  max_requests_per_day: 50
+
+working_dir: .working_dir/script2video

--- a/pipelines/idea2video_pipeline.py
+++ b/pipelines/idea2video_pipeline.py
@@ -10,6 +10,7 @@ from moviepy import VideoFileClip, concatenate_videoclips
 import yaml
 from langchain.chat_models import init_chat_model
 from tools.render_backend import RenderBackend
+from utils.provider_presets import resolve_chat_model_config
 
 
 class Idea2VideoPipeline:
@@ -37,7 +38,8 @@ class Idea2VideoPipeline:
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        chat_model = init_chat_model(**config["chat_model"]["init_args"])
+        chat_model_args = resolve_chat_model_config(config["chat_model"]["init_args"])
+        chat_model = init_chat_model(**chat_model_args)
         backend = RenderBackend.from_config(config)
 
         return cls(

--- a/pipelines/script2video_pipeline.py
+++ b/pipelines/script2video_pipeline.py
@@ -12,6 +12,7 @@ import yaml
 from interfaces import *
 from langchain.chat_models import init_chat_model
 from tools.render_backend import RenderBackend
+from utils.provider_presets import resolve_chat_model_config
 
 class Script2VideoPipeline:
 
@@ -49,7 +50,8 @@ class Script2VideoPipeline:
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        chat_model = init_chat_model(**config["chat_model"]["init_args"])
+        chat_model_args = resolve_chat_model_config(config["chat_model"]["init_args"])
+        chat_model = init_chat_model(**chat_model_args)
         backend = RenderBackend.from_config(config)
 
         return cls(

--- a/readme.md
+++ b/readme.md
@@ -440,6 +440,35 @@ For children, do not exceed 3 scenes.
 style = "Cartoon"
 ```
 
+#### Using MiniMax as Chat Model Provider
+
+[MiniMax](https://www.minimaxi.com/) models can be used as an alternative chat model provider. MiniMax offers OpenAI-compatible API access to models such as **MiniMax-M2.7** (1M context window) and **MiniMax-M2.5** (204K context).
+
+Simply set `model_provider: minimax` in your config — the base URL is resolved automatically:
+```yaml
+chat_model:
+  init_args:
+    model: MiniMax-M2.7
+    model_provider: minimax
+    api_key: <YOUR_MINIMAX_API_KEY>
+```
+
+Or export the API key as an environment variable and leave `api_key` empty:
+```bash
+export MINIMAX_API_KEY=<YOUR_KEY>
+```
+
+See `configs/idea2video_minimax.yaml` and `configs/script2video_minimax.yaml` for complete examples.
+
+| Model | Context | Note |
+|---|---|---|
+| MiniMax-M2.7 | 1M tokens | Latest, recommended |
+| MiniMax-M2.7-highspeed | 1M tokens | Fast variant |
+| MiniMax-M2.5 | 204K tokens | Stable |
+| MiniMax-M2.5-highspeed | 204K tokens | Fast variant |
+
+---
+
 main_script2video.py generates a video based on a specific script.
 You similarly need to set up the API configuration in configs/script2video.yaml file. Then, provide a scene script and the corresponding creative requirements in main_script2video.py, as shown below.
 ```python

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,165 @@
+"""Integration tests for MiniMax provider support.
+
+These tests verify end-to-end flow through the pipeline config loading
+and ``init_chat_model`` invocation.  They mock the LangChain factory so
+no real API calls are made.
+
+Heavy multimedia dependencies (moviepy, scenedetect, cv2, google-genai,
+etc.) are stubbed at the module level so the pipeline modules can be
+imported in a lightweight test environment.
+"""
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+# ---- stub heavy deps before any project imports ----
+_STUB_MODULES = [
+    "moviepy", "cv2", "scenedetect", "scenedetect.detectors",
+    "PIL", "PIL.Image",
+    "faiss",
+    "google", "google.genai", "google.genai.types", "google.genai.errors",
+    "langchain_community", "langchain_community.vectorstores",
+    "langchain_community.vectorstores.FAISS",
+]
+_saved = {}
+for _mod in _STUB_MODULES:
+    _saved[_mod] = sys.modules.get(_mod)
+    mock = MagicMock()
+    # Give stub a __spec__ so importlib.util.find_spec() works
+    mock.__spec__ = importlib.machinery.ModuleSpec(_mod, None)
+    mock.__path__ = []
+    sys.modules[_mod] = mock
+
+from utils.provider_presets import resolve_chat_model_config
+
+
+class TestPipelineConfigResolution(unittest.TestCase):
+    """Integration: config dict -> resolve -> init_chat_model kwargs."""
+
+    def _make_minimax_config(self, **overrides):
+        base = {
+            "model": "MiniMax-M2.7",
+            "model_provider": "minimax",
+            "api_key": "test-key",
+        }
+        base.update(overrides)
+        return base
+
+    def test_full_minimax_config_resolution(self):
+        config = self._make_minimax_config()
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["model_provider"], "openai")
+        self.assertEqual(resolved["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(resolved["model"], "MiniMax-M2.7")
+        self.assertEqual(resolved["api_key"], "test-key")
+
+    def test_minimax_highspeed_model(self):
+        config = self._make_minimax_config(model="MiniMax-M2.7-highspeed")
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["model"], "MiniMax-M2.7-highspeed")
+        self.assertEqual(resolved["model_provider"], "openai")
+
+    def test_minimax_m25_model(self):
+        config = self._make_minimax_config(model="MiniMax-M2.5")
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["model"], "MiniMax-M2.5")
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-api-key"})
+    def test_env_key_fallback_in_config(self):
+        config = {
+            "model": "MiniMax-M2.7",
+            "model_provider": "minimax",
+        }
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["api_key"], "env-api-key")
+
+    def test_openrouter_config_unchanged(self):
+        """Existing OpenRouter configs must not be affected."""
+        config = {
+            "model": "google/gemini-2.5-flash-lite-preview-09-2025",
+            "model_provider": "openai",
+            "api_key": "or-key",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["model_provider"], "openai")
+        self.assertEqual(resolved["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(resolved["model"], "google/gemini-2.5-flash-lite-preview-09-2025")
+
+    def test_init_chat_model_receives_openai_provider(self):
+        """Verify that resolved kwargs have model_provider='openai'."""
+        config = self._make_minimax_config()
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["model_provider"], "openai")
+        self.assertEqual(resolved["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(resolved["model"], "MiniMax-M2.7")
+
+    def test_temperature_clamping_in_pipeline_flow(self):
+        config = self._make_minimax_config(temperature=2.0)
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["temperature"], 1.0)
+
+    def test_extra_kwargs_preserved(self):
+        config = self._make_minimax_config(max_tokens=4096, top_p=0.9)
+        resolved = resolve_chat_model_config(config)
+        self.assertEqual(resolved["max_tokens"], 4096)
+        self.assertEqual(resolved["top_p"], 0.9)
+
+
+class TestPipelineInitFromConfig(unittest.TestCase):
+    """Integration: full pipeline init_from_config with MiniMax config."""
+
+    @patch("pipelines.idea2video_pipeline.init_chat_model")
+    @patch("pipelines.idea2video_pipeline.RenderBackend.from_config")
+    def test_idea2video_pipeline_minimax_config(self, mock_backend, mock_init):
+        mock_model = MagicMock()
+        mock_init.return_value = mock_model
+        mock_backend.return_value = MagicMock(image_generator=MagicMock(), video_generator=MagicMock())
+
+        from pipelines.idea2video_pipeline import Idea2VideoPipeline
+        pipeline = Idea2VideoPipeline.init_from_config("configs/idea2video_minimax.yaml")
+
+        mock_init.assert_called_once()
+        call_kwargs = mock_init.call_args[1]
+        self.assertEqual(call_kwargs["model_provider"], "openai")
+        self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+
+    @patch("pipelines.script2video_pipeline.init_chat_model")
+    @patch("pipelines.script2video_pipeline.RenderBackend.from_config")
+    def test_script2video_pipeline_minimax_config(self, mock_backend, mock_init):
+        mock_model = MagicMock()
+        mock_init.return_value = mock_model
+        mock_backend.return_value = MagicMock(image_generator=MagicMock(), video_generator=MagicMock())
+
+        from pipelines.script2video_pipeline import Script2VideoPipeline
+        pipeline = Script2VideoPipeline.init_from_config("configs/script2video_minimax.yaml")
+
+        mock_init.assert_called_once()
+        call_kwargs = mock_init.call_args[1]
+        self.assertEqual(call_kwargs["model_provider"], "openai")
+        self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+
+    @patch("pipelines.idea2video_pipeline.init_chat_model")
+    @patch("pipelines.idea2video_pipeline.RenderBackend.from_config")
+    def test_existing_openrouter_config_still_works(self, mock_backend, mock_init):
+        mock_model = MagicMock()
+        mock_init.return_value = mock_model
+        mock_backend.return_value = MagicMock(image_generator=MagicMock(), video_generator=MagicMock())
+
+        from pipelines.idea2video_pipeline import Idea2VideoPipeline
+        pipeline = Idea2VideoPipeline.init_from_config("configs/idea2video.yaml")
+
+        mock_init.assert_called_once()
+        call_kwargs = mock_init.call_args[1]
+        self.assertEqual(call_kwargs["model_provider"], "openai")
+        self.assertEqual(call_kwargs["base_url"], "https://openrouter.ai/api/v1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provider_presets.py
+++ b/tests/test_provider_presets.py
@@ -1,0 +1,176 @@
+"""Unit tests for utils.provider_presets."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from utils.provider_presets import (
+    PROVIDER_PRESETS,
+    resolve_chat_model_config,
+    detect_provider_from_env,
+)
+
+
+class TestProviderPresets(unittest.TestCase):
+    """Tests for the PROVIDER_PRESETS registry."""
+
+    def test_minimax_preset_exists(self):
+        self.assertIn("minimax", PROVIDER_PRESETS)
+
+    def test_minimax_preset_base_url(self):
+        self.assertEqual(
+            PROVIDER_PRESETS["minimax"]["base_url"],
+            "https://api.minimax.io/v1",
+        )
+
+    def test_minimax_preset_env_key(self):
+        self.assertEqual(PROVIDER_PRESETS["minimax"]["env_key"], "MINIMAX_API_KEY")
+
+    def test_minimax_preset_default_model(self):
+        self.assertEqual(PROVIDER_PRESETS["minimax"]["default_model"], "MiniMax-M2.7")
+
+    def test_minimax_preset_has_models_list(self):
+        models = PROVIDER_PRESETS["minimax"]["models"]
+        self.assertIn("MiniMax-M2.7", models)
+        self.assertIn("MiniMax-M2.7-highspeed", models)
+        self.assertIn("MiniMax-M2.5", models)
+        self.assertIn("MiniMax-M2.5-highspeed", models)
+
+    def test_minimax_preset_temperature_range(self):
+        lo, hi = PROVIDER_PRESETS["minimax"]["temperature_range"]
+        self.assertEqual(lo, 0.0)
+        self.assertEqual(hi, 1.0)
+
+
+class TestResolveChatModelConfig(unittest.TestCase):
+    """Tests for resolve_chat_model_config()."""
+
+    def test_unknown_provider_passes_through(self):
+        args = {"model_provider": "openai", "model": "gpt-4", "base_url": "https://example.com"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["model_provider"], "openai")
+        self.assertEqual(result["model"], "gpt-4")
+        self.assertEqual(result["base_url"], "https://example.com")
+
+    def test_no_model_provider_passes_through(self):
+        args = {"model": "gpt-4"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["model"], "gpt-4")
+
+    def test_minimax_rewrites_provider_to_openai(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk-test"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["model_provider"], "openai")
+
+    def test_minimax_sets_base_url(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk-test"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["base_url"], "https://api.minimax.io/v1")
+
+    def test_minimax_preserves_custom_base_url(self):
+        args = {
+            "model_provider": "minimax",
+            "model": "MiniMax-M2.7",
+            "api_key": "sk-test",
+            "base_url": "https://custom-proxy.example.com/v1",
+        }
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["base_url"], "https://custom-proxy.example.com/v1")
+
+    def test_minimax_defaults_model(self):
+        args = {"model_provider": "minimax", "api_key": "sk-test"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["model"], "MiniMax-M2.7")
+
+    def test_minimax_preserves_explicit_model(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.5-highspeed", "api_key": "sk-test"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["model"], "MiniMax-M2.5-highspeed")
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key-123"})
+    def test_minimax_reads_api_key_from_env(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["api_key"], "env-key-123")
+
+    def test_minimax_prefers_explicit_api_key_over_env(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "explicit-key"}
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
+            result = resolve_chat_model_config(args)
+        self.assertEqual(result["api_key"], "explicit-key")
+
+    def test_minimax_clamps_temperature_above_max(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": 1.5}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["temperature"], 1.0)
+
+    def test_minimax_clamps_temperature_below_min(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": -0.5}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["temperature"], 0.0)
+
+    def test_minimax_passes_valid_temperature(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": 0.7}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["temperature"], 0.7)
+
+    def test_minimax_temperature_zero_allowed(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": 0.0}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["temperature"], 0.0)
+
+    def test_minimax_no_temperature_key(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk"}
+        result = resolve_chat_model_config(args)
+        self.assertNotIn("temperature", result)
+
+    def test_minimax_temperature_none_ignored(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": None}
+        result = resolve_chat_model_config(args)
+        self.assertIsNone(result["temperature"])
+
+    def test_original_dict_not_mutated(self):
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk"}
+        resolve_chat_model_config(args)
+        self.assertEqual(args["model_provider"], "minimax")
+
+    def test_empty_model_string_gets_default(self):
+        args = {"model_provider": "minimax", "model": "", "api_key": "sk"}
+        result = resolve_chat_model_config(args)
+        self.assertEqual(result["model"], "MiniMax-M2.7")
+
+
+class TestDetectProviderFromEnv(unittest.TestCase):
+    """Tests for detect_provider_from_env()."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False)
+    def test_detects_minimax(self):
+        self.assertEqual(detect_provider_from_env(), "minimax")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_returns_none_when_no_keys(self):
+        self.assertIsNone(detect_provider_from_env())
+
+
+class TestConfigYAMLLoading(unittest.TestCase):
+    """Test that MiniMax example config files are valid YAML."""
+
+    def test_idea2video_minimax_yaml(self):
+        import yaml
+        path = os.path.join(os.path.dirname(__file__), "..", "configs", "idea2video_minimax.yaml")
+        with open(path) as f:
+            config = yaml.safe_load(f)
+        self.assertEqual(config["chat_model"]["init_args"]["model_provider"], "minimax")
+        self.assertEqual(config["chat_model"]["init_args"]["model"], "MiniMax-M2.7")
+
+    def test_script2video_minimax_yaml(self):
+        import yaml
+        path = os.path.join(os.path.dirname(__file__), "..", "configs", "script2video_minimax.yaml")
+        with open(path) as f:
+            config = yaml.safe_load(f)
+        self.assertEqual(config["chat_model"]["init_args"]["model_provider"], "minimax")
+        self.assertEqual(config["chat_model"]["init_args"]["model"], "MiniMax-M2.7")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/provider_presets.py
+++ b/utils/provider_presets.py
@@ -1,0 +1,101 @@
+"""
+Provider preset system for ViMax chat model configuration.
+
+Supports auto-detection and resolution of LLM provider settings,
+allowing users to specify a provider name (e.g., ``minimax``) instead
+of manually configuring base_url and model details.
+"""
+
+import os
+import logging
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Provider presets
+# ---------------------------------------------------------------------------
+
+PROVIDER_PRESETS: Dict[str, Dict[str, Any]] = {
+    "minimax": {
+        "base_url": "https://api.minimax.io/v1",
+        "env_key": "MINIMAX_API_KEY",
+        "default_model": "MiniMax-M2.7",
+        "models": [
+            "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+        ],
+        "temperature_range": (0.0, 1.0),
+    },
+}
+
+
+def resolve_chat_model_config(init_args: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve provider presets and return final ``init_chat_model`` kwargs.
+
+    If ``model_provider`` matches a known preset (e.g. ``minimax``), the
+    returned dict will have:
+
+    * ``model_provider`` rewritten to ``"openai"`` (OpenAI-compatible API)
+    * ``base_url`` filled in from the preset when not already set
+    * ``api_key`` sourced from the environment when not already set
+    * ``model`` defaulted to the preset's default model when not already set
+    * ``temperature`` clamped to the provider's supported range
+
+    For unknown providers the dict is returned unchanged.
+    """
+    args = dict(init_args)  # shallow copy
+    provider = args.get("model_provider", "openai")
+
+    preset = PROVIDER_PRESETS.get(provider)
+    if preset is None:
+        return args
+
+    # base_url
+    if not args.get("base_url"):
+        args["base_url"] = preset["base_url"]
+
+    # api_key – fall back to env var
+    if not args.get("api_key"):
+        env_key = preset.get("env_key", "")
+        env_val = os.environ.get(env_key, "")
+        if env_val:
+            args["api_key"] = env_val
+            logger.info("Using %s API key from environment variable %s", provider, env_key)
+
+    # default model
+    if not args.get("model"):
+        args["model"] = preset["default_model"]
+        logger.info("Defaulting to model %s for provider %s", args["model"], provider)
+
+    # temperature clamping
+    temp_range = preset.get("temperature_range")
+    if temp_range and "temperature" in args and args["temperature"] is not None:
+        lo, hi = temp_range
+        original = args["temperature"]
+        args["temperature"] = max(lo, min(hi, original))
+        if args["temperature"] != original:
+            logger.warning(
+                "Clamped temperature %.2f -> %.2f for provider %s",
+                original, args["temperature"], provider,
+            )
+
+    # rewrite to openai-compatible provider for LangChain
+    args["model_provider"] = "openai"
+
+    return args
+
+
+def detect_provider_from_env() -> Optional[str]:
+    """Return the name of a provider whose API key is found in the environment.
+
+    Checks ``PROVIDER_PRESETS`` in definition order and returns the first
+    match, or ``None`` if no key is set.
+    """
+    for name, preset in PROVIDER_PRESETS.items():
+        env_key = preset.get("env_key", "")
+        if env_key and os.environ.get(env_key):
+            return name
+    return None


### PR DESCRIPTION
## Summary

- Add a **provider preset system** (`utils/provider_presets.py`) that lets users set `model_provider: minimax` in config YAML files — the base URL (`https://api.minimax.io/v1`), default model, and `MINIMAX_API_KEY` env var are resolved automatically
- Integrate `resolve_chat_model_config()` into both `Idea2VideoPipeline` and `Script2VideoPipeline` `init_from_config()` methods
- Add example config files: `configs/idea2video_minimax.yaml` and `configs/script2video_minimax.yaml`
- Add [MiniMax](https://www.minimaxi.com/) usage documentation to the README with a model comparison table
- Temperature clamping to MiniMax supported range `[0.0, 1.0]`

### Supported MiniMax Models

| Model | Context | Note |
|---|---|---|
| MiniMax-M2.7 | 1M tokens | Latest, recommended |
| MiniMax-M2.7-highspeed | 1M tokens | Fast variant |
| MiniMax-M2.5 | 204K tokens | Stable |
| MiniMax-M2.5-highspeed | 204K tokens | Fast variant |

### Files Changed (9 files, 545 additions)

- `utils/provider_presets.py` — Provider preset registry, config resolver, env auto-detect
- `pipelines/idea2video_pipeline.py` — Integrate config resolver
- `pipelines/script2video_pipeline.py` — Integrate config resolver
- `configs/idea2video_minimax.yaml` — MiniMax example config
- `configs/script2video_minimax.yaml` — MiniMax example config
- `readme.md` — MiniMax provider documentation
- `tests/test_provider_presets.py` — 27 unit tests
- `tests/test_minimax_integration.py` — 11 integration tests

## Test Plan

- [x] 27 unit tests covering preset registry, config resolution, temperature clamping, env var fallback, and YAML loading
- [x] 11 integration tests verifying pipeline init_from_config with MiniMax and existing OpenRouter configs
- [x] All 38 tests passing
- [ ] Manual verification with MiniMax API key