### PR TITLE
docs: fix README heading spacing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ https://github.com/user-attachments/assets/5bad46b2-8276-4e1d-9480-3522640744b2
 - [🚀 Quick Start](#quick-start)
 
 ---
-## 💡Key Features
+## 💡 Key Features
 
 <br/>
 


### PR DESCRIPTION
Adds a missing space in a README heading for consistency.