### PR TITLE
fix: initialize Novel2MoviePipeline dependencies

### DIFF
--- a/pipelines/novel2movie_pipeline.py
+++ b/pipelines/novel2movie_pipeline.py
@@ -6,20 +6,47 @@ import yaml
 import json
 import importlib
 import asyncio
-from typing import List, Dict
+from typing import Any, List, Dict
 from langchain.embeddings import CacheBackedEmbeddings
 from langchain.storage import LocalFileStore
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 from PIL import Image
 
-from components.event import Event
-from components.scene import Scene
-from components.character import CharacterInScene, CharacterInNovel, CharacterInEvent
-from pipelines.base import BasePipeline
+from interfaces import (
+    Event,
+    Scene,
+    CharacterInScene,
+    CharacterInNovel,
+    CharacterInEvent,
+)
 from tenacity import retry
 
-class Novel2MoviePipeline(BasePipeline):
+class Novel2MoviePipeline:
+    def __init__(
+        self,
+        novel_compressor: Any,
+        event_extractor: Any,
+        embeddings: Any,
+        rerank_model: Any,
+        scene_extractor: Any,
+        global_information_planner: Any,
+        image_generator: Any,
+        rewriter: Any,
+        script2video_pipeline: Any,
+        working_dir: str,
+    ):
+        self.novel_compressor = novel_compressor
+        self.event_extractor = event_extractor
+        self.embeddings = embeddings
+        self.rerank_model = rerank_model
+        self.scene_extractor = scene_extractor
+        self.global_information_planner = global_information_planner
+        self.image_generator = image_generator
+        self.rewriter = rewriter
+        self.script2video_pipeline = script2video_pipeline
+        self.working_dir = working_dir
+        os.makedirs(self.working_dir, exist_ok=True)
 
     async def __call__(
         self,

--- a/tests/test_novel2movie_pipeline_init.py
+++ b/tests/test_novel2movie_pipeline_init.py
@@ -1,0 +1,52 @@
+"""Tests for Novel2MoviePipeline initialization."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+class TestNovel2MoviePipelineInit(unittest.TestCase):
+    def _class_node(self):
+        source = Path("pipelines/novel2movie_pipeline.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        return next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "Novel2MoviePipeline"
+        )
+
+    def test_initializes_runtime_dependencies(self):
+        class_node = self._class_node()
+        init_node = next(
+            node
+            for node in class_node.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+        assigned = {
+            target.attr
+            for node in ast.walk(init_node)
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        }
+
+        self.assertTrue(
+            {
+                "working_dir",
+                "novel_compressor",
+                "event_extractor",
+                "embeddings",
+                "rerank_model",
+                "scene_extractor",
+                "global_information_planner",
+                "image_generator",
+                "rewriter",
+                "script2video_pipeline",
+            }.issubset(assigned)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #43

## Summary
- Add an explicit `Novel2MoviePipeline.__init__` that stores the dependencies used by `__call__`, including `working_dir`.
- Create the working directory during initialization, matching the other pipeline classes.
- Update stale imports to use the current `interfaces` package and remove the missing `BasePipeline` inheritance.
- Add a regression test that checks the initializer assigns the runtime dependencies the pipeline uses.

## Reproduction before fix
- `python3 -m unittest tests.test_novel2movie_pipeline_init` failed because `Novel2MoviePipeline` had no `__init__`.

## Validation after fix
- `python3 -m unittest tests.test_novel2movie_pipeline_init`
- `python3 -m py_compile pipelines/novel2movie_pipeline.py tests/test_novel2movie_pipeline_init.py`
- `git diff --check HEAD~1..HEAD`

## Notes
- I also ran `python3 -m unittest discover tests`; existing MiniMax integration tests fail with `module 'pipelines' has no attribute ...` patch-target errors, which appears unrelated to this change.