### PR TITLE
Upgrade minimax provider to support M3 model

### DIFF
--- a/configs/idea2video_minimax.yaml
+++ b/configs/idea2video_minimax.yaml
@@ -1,16 +1,15 @@
 # Example configuration using MiniMax as the chat model provider.
-# MiniMax M2.7 is used via its OpenAI-compatible API.
+# MiniMax M3 is used via its OpenAI-compatible API.
 #
 # Set your API key below or export MINIMAX_API_KEY in the environment.
 # Available models:
-#   - MiniMax-M2.7           (latest, 1M context)
+#   - MiniMax-M3             (latest, recommended)
+#   - MiniMax-M2.7           (previous generation)
 #   - MiniMax-M2.7-highspeed (fast variant)
-#   - MiniMax-M2.5           (204K context)
-#   - MiniMax-M2.5-highspeed (fast variant)
 
 chat_model:
   init_args:
-    model: MiniMax-M2.7
+    model: MiniMax-M3
     model_provider: minimax
     api_key: <YOUR_MINIMAX_API_KEY>
     # base_url is auto-resolved to https://api.minimax.io/v1

--- a/configs/script2video_minimax.yaml
+++ b/configs/script2video_minimax.yaml
@@ -1,16 +1,15 @@
 # Example configuration using MiniMax as the chat model provider.
-# MiniMax M2.7 is used via its OpenAI-compatible API.
+# MiniMax M3 is used via its OpenAI-compatible API.
 #
 # Set your API key below or export MINIMAX_API_KEY in the environment.
 # Available models:
-#   - MiniMax-M2.7           (latest, 1M context)
+#   - MiniMax-M3             (latest, recommended)
+#   - MiniMax-M2.7           (previous generation)
 #   - MiniMax-M2.7-highspeed (fast variant)
-#   - MiniMax-M2.5           (204K context)
-#   - MiniMax-M2.5-highspeed (fast variant)
 
 chat_model:
   init_args:
-    model: MiniMax-M2.7
+    model: MiniMax-M3
     model_provider: minimax
     api_key: <YOUR_MINIMAX_API_KEY>
     # base_url is auto-resolved to https://api.minimax.io/v1

--- a/readme.md
+++ b/readme.md
@@ -439,13 +439,13 @@ style = "Cartoon"
 
 #### Using MiniMax as Chat Model Provider
 
-[MiniMax](https://www.minimaxi.com/) models can be used as an alternative chat model provider. MiniMax offers OpenAI-compatible API access to models such as **MiniMax-M2.7** (1M context window) and **MiniMax-M2.5** (204K context).
+[MiniMax](https://www.minimaxi.com/) models can be used as an alternative chat model provider. MiniMax offers OpenAI-compatible API access to models such as **MiniMax-M3** (latest) and **MiniMax-M2.7** (1M context window).
 
 Simply set `model_provider: minimax` in your config — the base URL is resolved automatically:
 ```yaml
 chat_model:
   init_args:
-    model: MiniMax-M2.7
+    model: MiniMax-M3
     model_provider: minimax
     api_key: <YOUR_MINIMAX_API_KEY>
 ```
@@ -457,12 +457,11 @@ export MINIMAX_API_KEY=<YOUR_KEY>
 
 See `configs/idea2video_minimax.yaml` and `configs/script2video_minimax.yaml` for complete examples.
 
-| Model | Context | Note |
-|---|---|---|
-| MiniMax-M2.7 | 1M tokens | Latest, recommended |
-| MiniMax-M2.7-highspeed | 1M tokens | Fast variant |
-| MiniMax-M2.5 | 204K tokens | Stable |
-| MiniMax-M2.5-highspeed | 204K tokens | Fast variant |
+| Model | Note |
+|---|---|
+| MiniMax-M3 | Latest, recommended |
+| MiniMax-M2.7 | Previous generation, 1M context |
+| MiniMax-M2.7-highspeed | Fast variant of M2.7 |
 
 ---
 

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -42,7 +42,7 @@ class TestPipelineConfigResolution(unittest.TestCase):
 
     def _make_minimax_config(self, **overrides):
         base = {
-            "model": "MiniMax-M2.7",
+            "model": "MiniMax-M3",
             "model_provider": "minimax",
             "api_key": "test-key",
         }
@@ -54,7 +54,7 @@ class TestPipelineConfigResolution(unittest.TestCase):
         resolved = resolve_chat_model_config(config)
         self.assertEqual(resolved["model_provider"], "openai")
         self.assertEqual(resolved["base_url"], "https://api.minimax.io/v1")
-        self.assertEqual(resolved["model"], "MiniMax-M2.7")
+        self.assertEqual(resolved["model"], "MiniMax-M3")
         self.assertEqual(resolved["api_key"], "test-key")
 
     def test_minimax_highspeed_model(self):
@@ -63,15 +63,15 @@ class TestPipelineConfigResolution(unittest.TestCase):
         self.assertEqual(resolved["model"], "MiniMax-M2.7-highspeed")
         self.assertEqual(resolved["model_provider"], "openai")
 
-    def test_minimax_m25_model(self):
-        config = self._make_minimax_config(model="MiniMax-M2.5")
+    def test_minimax_m27_model(self):
+        config = self._make_minimax_config(model="MiniMax-M2.7")
         resolved = resolve_chat_model_config(config)
-        self.assertEqual(resolved["model"], "MiniMax-M2.5")
+        self.assertEqual(resolved["model"], "MiniMax-M2.7")
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-api-key"})
     def test_env_key_fallback_in_config(self):
         config = {
-            "model": "MiniMax-M2.7",
+            "model": "MiniMax-M3",
             "model_provider": "minimax",
         }
         resolved = resolve_chat_model_config(config)
@@ -96,7 +96,7 @@ class TestPipelineConfigResolution(unittest.TestCase):
         resolved = resolve_chat_model_config(config)
         self.assertEqual(resolved["model_provider"], "openai")
         self.assertEqual(resolved["base_url"], "https://api.minimax.io/v1")
-        self.assertEqual(resolved["model"], "MiniMax-M2.7")
+        self.assertEqual(resolved["model"], "MiniMax-M3")
 
     def test_temperature_clamping_in_pipeline_flow(self):
         config = self._make_minimax_config(temperature=2.0)
@@ -127,7 +127,7 @@ class TestPipelineInitFromConfig(unittest.TestCase):
         call_kwargs = mock_init.call_args[1]
         self.assertEqual(call_kwargs["model_provider"], "openai")
         self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
-        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertEqual(call_kwargs["model"], "MiniMax-M3")
 
     @patch("pipelines.script2video_pipeline.init_chat_model")
     @patch("pipelines.script2video_pipeline.RenderBackend.from_config")
@@ -143,7 +143,7 @@ class TestPipelineInitFromConfig(unittest.TestCase):
         call_kwargs = mock_init.call_args[1]
         self.assertEqual(call_kwargs["model_provider"], "openai")
         self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
-        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertEqual(call_kwargs["model"], "MiniMax-M3")
 
     @patch("pipelines.idea2video_pipeline.init_chat_model")
     @patch("pipelines.idea2video_pipeline.RenderBackend.from_config")

--- a/tests/test_provider_presets.py
+++ b/tests/test_provider_presets.py
@@ -27,14 +27,13 @@ class TestProviderPresets(unittest.TestCase):
         self.assertEqual(PROVIDER_PRESETS["minimax"]["env_key"], "MINIMAX_API_KEY")
 
     def test_minimax_preset_default_model(self):
-        self.assertEqual(PROVIDER_PRESETS["minimax"]["default_model"], "MiniMax-M2.7")
+        self.assertEqual(PROVIDER_PRESETS["minimax"]["default_model"], "MiniMax-M3")
 
     def test_minimax_preset_has_models_list(self):
         models = PROVIDER_PRESETS["minimax"]["models"]
+        self.assertIn("MiniMax-M3", models)
         self.assertIn("MiniMax-M2.7", models)
         self.assertIn("MiniMax-M2.7-highspeed", models)
-        self.assertIn("MiniMax-M2.5", models)
-        self.assertIn("MiniMax-M2.5-highspeed", models)
 
     def test_minimax_preset_temperature_range(self):
         lo, hi = PROVIDER_PRESETS["minimax"]["temperature_range"]
@@ -58,19 +57,19 @@ class TestResolveChatModelConfig(unittest.TestCase):
         self.assertEqual(result["model"], "gpt-4")
 
     def test_minimax_rewrites_provider_to_openai(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk-test"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk-test"}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["model_provider"], "openai")
 
     def test_minimax_sets_base_url(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk-test"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk-test"}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["base_url"], "https://api.minimax.io/v1")
 
     def test_minimax_preserves_custom_base_url(self):
         args = {
             "model_provider": "minimax",
-            "model": "MiniMax-M2.7",
+            "model": "MiniMax-M3",
             "api_key": "sk-test",
             "base_url": "https://custom-proxy.example.com/v1",
         }
@@ -80,64 +79,64 @@ class TestResolveChatModelConfig(unittest.TestCase):
     def test_minimax_defaults_model(self):
         args = {"model_provider": "minimax", "api_key": "sk-test"}
         result = resolve_chat_model_config(args)
-        self.assertEqual(result["model"], "MiniMax-M2.7")
+        self.assertEqual(result["model"], "MiniMax-M3")
 
     def test_minimax_preserves_explicit_model(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.5-highspeed", "api_key": "sk-test"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M2.7-highspeed", "api_key": "sk-test"}
         result = resolve_chat_model_config(args)
-        self.assertEqual(result["model"], "MiniMax-M2.5-highspeed")
+        self.assertEqual(result["model"], "MiniMax-M2.7-highspeed")
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key-123"})
     def test_minimax_reads_api_key_from_env(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3"}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["api_key"], "env-key-123")
 
     def test_minimax_prefers_explicit_api_key_over_env(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "explicit-key"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "explicit-key"}
         with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
             result = resolve_chat_model_config(args)
         self.assertEqual(result["api_key"], "explicit-key")
 
     def test_minimax_clamps_temperature_above_max(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": 1.5}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk", "temperature": 1.5}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["temperature"], 1.0)
 
     def test_minimax_clamps_temperature_below_min(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": -0.5}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk", "temperature": -0.5}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["temperature"], 0.0)
 
     def test_minimax_passes_valid_temperature(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": 0.7}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk", "temperature": 0.7}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["temperature"], 0.7)
 
     def test_minimax_temperature_zero_allowed(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": 0.0}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk", "temperature": 0.0}
         result = resolve_chat_model_config(args)
         self.assertEqual(result["temperature"], 0.0)
 
     def test_minimax_no_temperature_key(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk"}
         result = resolve_chat_model_config(args)
         self.assertNotIn("temperature", result)
 
     def test_minimax_temperature_none_ignored(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk", "temperature": None}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk", "temperature": None}
         result = resolve_chat_model_config(args)
         self.assertIsNone(result["temperature"])
 
     def test_original_dict_not_mutated(self):
-        args = {"model_provider": "minimax", "model": "MiniMax-M2.7", "api_key": "sk"}
+        args = {"model_provider": "minimax", "model": "MiniMax-M3", "api_key": "sk"}
         resolve_chat_model_config(args)
         self.assertEqual(args["model_provider"], "minimax")
 
     def test_empty_model_string_gets_default(self):
         args = {"model_provider": "minimax", "model": "", "api_key": "sk"}
         result = resolve_chat_model_config(args)
-        self.assertEqual(result["model"], "MiniMax-M2.7")
+        self.assertEqual(result["model"], "MiniMax-M3")
 
 
 class TestDetectProviderFromEnv(unittest.TestCase):
@@ -161,7 +160,7 @@ class TestConfigYAMLLoading(unittest.TestCase):
         with open(path) as f:
             config = yaml.safe_load(f)
         self.assertEqual(config["chat_model"]["init_args"]["model_provider"], "minimax")
-        self.assertEqual(config["chat_model"]["init_args"]["model"], "MiniMax-M2.7")
+        self.assertEqual(config["chat_model"]["init_args"]["model"], "MiniMax-M3")
 
     def test_script2video_minimax_yaml(self):
         import yaml
@@ -169,7 +168,7 @@ class TestConfigYAMLLoading(unittest.TestCase):
         with open(path) as f:
             config = yaml.safe_load(f)
         self.assertEqual(config["chat_model"]["init_args"]["model_provider"], "minimax")
-        self.assertEqual(config["chat_model"]["init_args"]["model"], "MiniMax-M2.7")
+        self.assertEqual(config["chat_model"]["init_args"]["model"], "MiniMax-M3")
 
 
 if __name__ == "__main__":

--- a/utils/provider_presets.py
+++ b/utils/provider_presets.py
@@ -20,12 +20,11 @@ PROVIDER_PRESETS: Dict[str, Dict[str, Any]] = {
     "minimax": {
         "base_url": "https://api.minimax.io/v1",
         "env_key": "MINIMAX_API_KEY",
-        "default_model": "MiniMax-M2.7",
+        "default_model": "MiniMax-M3",
         "models": [
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
         ],
         "temperature_range": (0.0, 1.0),
     },


### PR DESCRIPTION
## Summary

This PR upgrades the `minimax` chat-model provider preset to support the latest `MiniMax-M3` model, while preserving the previous-generation models that users may still prefer.

## Changes

- `utils/provider_presets.py`
  - Add `MiniMax-M3` to the model list and set it as the new `default_model`.
  - Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`.
  - Remove the older `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` entries.
- `configs/idea2video_minimax.yaml`, `configs/script2video_minimax.yaml`
  - Update example configs to use `model: MiniMax-M3`.
  - Refresh the inline model-list comment.
- `readme.md`
  - Update the example snippet and the available-models table to reflect the new default.
- `tests/test_provider_presets.py`, `tests/test_minimax_integration.py`
  - Update assertions for the new default model and model list.

`base_url`, `env_key`, and `temperature_range` are unchanged.

## Test plan

- [x] `python -m unittest tests.test_provider_presets` (27 tests pass)
- [x] `python -m unittest tests.test_minimax_integration` (11 tests pass)
- [x] `yaml.safe_load` of both updated config files succeeds