### PR TITLE
fix: correct pyproject readme path case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "autolongvideogeneration"
 version = "0.1.0"
 description = "Add your description here"
-readme = "README.md"
+readme = "readme.md"
 requires-python = ">=3.12"
 dependencies = [
     "chardet>=5.2.0",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,20 @@
+"""Tests for package metadata files."""
+
+import pathlib
+import tomllib
+import unittest
+
+
+class TestProjectMetadata(unittest.TestCase):
+    def test_pyproject_readme_path_exists_case_sensitively(self):
+        project_root = pathlib.Path(__file__).resolve().parents[1]
+        pyproject = tomllib.loads((project_root / "pyproject.toml").read_text(encoding="utf-8"))
+
+        readme_path = project_root / pyproject["project"]["readme"]
+
+        self.assertTrue(readme_path.exists())
+        self.assertEqual(readme_path.name, "readme.md")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Updates `pyproject.toml` to reference the existing `readme.md` file and adds a small metadata test for the path.

## Why
The repository uses a lowercase `readme.md`, but `pyproject.toml` pointed at `README.md`. That works on case-insensitive filesystems, but can fail package metadata/build tooling on case-sensitive systems.

## Before / After
Before: package metadata referenced `README.md`, which is not the exact file name in the repo.
After: package metadata references `readme.md`, matching the checked-in file.

## Verification
- `python -m unittest tests.test_project_metadata`
- `git diff --check`