### PR TITLE
fix: read pipeline configs as utf-8

### DIFF
--- a/pipelines/idea2video_pipeline.py
+++ b/pipelines/idea2video_pipeline.py
@@ -35,7 +35,7 @@ class Idea2VideoPipeline:
 
     @classmethod
     def init_from_config(cls, config_path: str):
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         chat_model_args = resolve_chat_model_config(config["chat_model"]["init_args"])

--- a/pipelines/script2video_pipeline.py
+++ b/pipelines/script2video_pipeline.py
@@ -47,7 +47,7 @@ class Script2VideoPipeline:
 
     @classmethod
     def init_from_config(cls, config_path: str):
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         chat_model_args = resolve_chat_model_config(config["chat_model"]["init_args"])

--- a/tests/test_config_loading_encoding.py
+++ b/tests/test_config_loading_encoding.py
@@ -1,0 +1,42 @@
+"""Structural tests for pipeline config loading."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+class TestConfigLoadingEncoding(unittest.TestCase):
+    def _init_from_config_open_calls(self, path):
+        tree = ast.parse(Path(path).read_text(encoding="utf-8"))
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "open"
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "config_path"
+        ]
+
+    def test_pipeline_config_files_are_read_as_utf8(self):
+        for path in [
+            "pipelines/idea2video_pipeline.py",
+            "pipelines/script2video_pipeline.py",
+        ]:
+            with self.subTest(path=path):
+                calls = self._init_from_config_open_calls(path)
+                self.assertTrue(calls)
+                self.assertTrue(
+                    any(
+                        keyword.arg == "encoding"
+                        and isinstance(keyword.value, ast.Constant)
+                        and keyword.value.value == "utf-8"
+                        for call in calls
+                        for keyword in call.keywords
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Adds explicit `encoding="utf-8"` when the idea2video and script2video pipelines read YAML config files.

## Why
ViMax includes multilingual docs/config comments and is used across platforms. Relying on the process default encoding can make config loading behave differently on Windows or non-UTF-8 locales.

## Before / After
Before: `init_from_config()` used the platform default encoding.
After: config YAML files are read consistently as UTF-8.

## Verification
- `python -m unittest tests.test_config_loading_encoding tests.test_provider_presets`
- `git diff --check`