### PR TITLE
Bound all unbounded retry and polling loops; validate LLM-built camera tree

### DIFF
--- a/agents/camera_image_generator.py
+++ b/agents/camera_image_generator.py
@@ -140,13 +140,18 @@ class CameraImageGenerator:
 
         chain = self.chat_model | parser
         response: CameraTreeResponse = await chain.ainvoke(messages)
+        if len(response.camera_parent_items) != len(cameras):
+            raise ValueError(
+                f"Camera tree response has {len(response.camera_parent_items)} items "
+                f"for {len(cameras)} cameras."
+            )
         for cam, parent_cam_item in zip(cameras, response.camera_parent_items):
             cam.parent_cam_idx = parent_cam_item.parent_cam_idx if parent_cam_item is not None else None
             cam.parent_shot_idx = parent_cam_item.parent_shot_idx if parent_cam_item is not None else None
             cam.reason = parent_cam_item.reason if parent_cam_item is not None else None
-            cam.parent_shot_idx = parent_cam_item.parent_shot_idx if parent_cam_item is not None else None
             cam.is_parent_fully_covers_child = parent_cam_item.is_parent_fully_covers_child if parent_cam_item is not None else None
             cam.missing_info = parent_cam_item.missing_info if parent_cam_item is not None else None
+        _validate_camera_tree(cameras)
         return cameras
 
 
@@ -219,3 +224,28 @@ class CameraImageGenerator:
             size="1600x900",
         )
         return image_output
+
+
+def _validate_camera_tree(cameras: List[Camera]) -> None:
+    """Reject parent assignments that would deadlock frame generation.
+
+    Frame generation for a camera awaits an event set by its parent's shot, so a
+    cycle (or a parent pointing at itself or at a nonexistent camera) would make
+    every camera in the loop wait forever with no error surfaced.
+    """
+    by_idx = {cam.idx: cam for cam in cameras}
+    for cam in cameras:
+        if cam.parent_cam_idx is None:
+            continue
+        if cam.parent_cam_idx == cam.idx:
+            raise ValueError(f"Camera {cam.idx} lists itself as its parent.")
+        if cam.parent_cam_idx not in by_idx:
+            raise ValueError(f"Camera {cam.idx} references unknown parent camera {cam.parent_cam_idx}.")
+    for cam in cameras:
+        seen = set()
+        current = cam
+        while current.parent_cam_idx is not None:
+            if current.idx in seen:
+                raise ValueError(f"Cycle detected in camera parent graph involving camera {current.idx}.")
+            seen.add(current.idx)
+            current = by_idx[current.parent_cam_idx]

--- a/agents/event_extractor.py
+++ b/agents/event_extractor.py
@@ -92,6 +92,10 @@ class EventExtractor:
         self.parser = PydanticOutputParser(pydantic_object=Event)
 
 
+    # Cap on extracted events: is_last is asserted by the LLM only, so without a
+    # bound a model that never sets it would loop (and spend tokens) forever.
+    max_events = 50
+
     def __call__(
         self,
         novel_text: str,
@@ -100,6 +104,11 @@ class EventExtractor:
 
         events = []
         while True:
+            if len(events) >= self.max_events:
+                raise RuntimeError(
+                    f"Event extraction exceeded the maximum of {self.max_events} events "
+                    "without an is_last marker; aborting to avoid unbounded LLM calls."
+                )
             event = self.extract_next_event(novel_text, events)
 
             events.append(event)

--- a/pipelines/novel2movie_pipeline.py
+++ b/pipelines/novel2movie_pipeline.py
@@ -138,6 +138,7 @@ class Novel2MoviePipeline:
             with open(event_path, "r", encoding="utf-8") as f:
                 extracted_events.append(Event.model_validate(json.load(f)))
         while len(extracted_events) == 0 or not extracted_events[-1].is_last:
+            _ensure_extraction_cap(len(extracted_events), MAX_EXTRACTED_EVENTS, "events")
             next_event = self.event_extractor.extract_next_event(
                 novel_text=compressed_novel,
                 extracted_events=extracted_events,
@@ -224,6 +225,7 @@ class Novel2MoviePipeline:
                 scenes_dir = os.path.join(working_dir_scenes, f"event_{event.index}")
                 os.makedirs(scenes_dir, exist_ok=True)
                 while len(previous_scenes) == 0 or not previous_scenes[-1].is_last:
+                    _ensure_extraction_cap(len(previous_scenes), MAX_SCENES_PER_EVENT, "scenes")
                     next_scene = await self.scene_extractor.get_next_scene(
                         relevant_chunks=list(event_idx_to_relevant_chunk_score_dict.get(event.index, {}).keys()),
                         event=event,
@@ -990,3 +992,17 @@ class Novel2MoviePipeline:
                 )
                 print(f"✅ Generated video for event {event.index}, scene {scene.idx}, saved to {scene_video_dir}")
         print("📋 Step 7: Generate the video for each scene".center(80, "-"))
+
+
+# is_last flags are asserted by the LLM only; cap the extraction loops so a
+# model that never sets one cannot spend tokens forever.
+MAX_EXTRACTED_EVENTS = 50
+MAX_SCENES_PER_EVENT = 30
+
+
+def _ensure_extraction_cap(count: int, cap: int, what: str) -> None:
+    if count >= cap:
+        raise RuntimeError(
+            f"Extraction reached {count} {what} without an is_last marker (cap: {cap}); "
+            "aborting to avoid unbounded LLM calls."
+        )

--- a/tests/test_hang_guards.py
+++ b/tests/test_hang_guards.py
@@ -1,0 +1,229 @@
+"""Regression tests for unbounded retry/polling loops and LLM-trusted graphs.
+
+The bugs under test previously looped forever. Each test's fakes succeed after
+N calls, so the buggy code produces a fast assertion failure (extra calls or a
+missing exception) rather than hanging the suite; the fixed code must give up
+before the fake ever succeeds.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import requests
+
+from agents.camera_image_generator import _validate_camera_tree
+from agents.event_extractor import EventExtractor
+from interfaces.camera import Camera
+from interfaces.event import Event
+from pipelines.novel2movie_pipeline import _ensure_extraction_cap
+from tools.video_generator_doubao_seedance_yunwu_api import VideoGeneratorDoubaoSeedanceYunwuAPI
+from tools.video_generator_omni_yunwu_api import VideoGeneratorOmniYunwuAPI
+from utils.image import download_image
+from utils.video import download_video
+
+
+def _no_sleep(fn):
+    retrying = getattr(fn, "retry", None)
+    if retrying is not None:
+        retrying.sleep = lambda seconds: None
+
+
+class TestDownloadRetries(unittest.TestCase):
+    def setUp(self):
+        _no_sleep(download_image)
+        _no_sleep(download_video)
+
+    def test_download_image_gives_up_on_persistent_network_error(self):
+        calls = {"n": 0}
+
+        def flaky_get(url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 10:
+                raise requests.ConnectionError("connection refused")
+            return MagicMock()
+
+        with patch("utils.image.requests.get", side_effect=flaky_get):
+            with self.assertRaises(requests.ConnectionError):
+                download_image("http://example.com/a.png", "/tmp/a.png")
+        self.assertLessEqual(calls["n"], 5, "retry must be bounded, not retry-until-success")
+
+    def test_download_image_does_not_retry_client_errors(self):
+        calls = {"n": 0}
+        gone = MagicMock()
+        gone.raise_for_status.side_effect = requests.HTTPError(
+            "404", response=MagicMock(status_code=404)
+        )
+
+        def expired_then_ok(url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return gone
+            return MagicMock()
+
+        with patch("utils.image.requests.get", side_effect=expired_then_ok):
+            with self.assertRaises(requests.HTTPError):
+                download_image("http://example.com/expired.png", "/tmp/a.png")
+        self.assertEqual(calls["n"], 1, "4xx responses must fail fast, not be retried")
+
+    def test_download_image_sets_a_timeout(self):
+        captured = {}
+
+        def record_get(url, **kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("utils.image.requests.get", side_effect=record_get):
+            download_image("http://example.com/a.png", "/tmp/a.png")
+        self.assertIsNotNone(captured.get("timeout"), "requests.get must not wait forever")
+
+    def test_download_video_gives_up_on_persistent_network_error(self):
+        calls = {"n": 0}
+
+        def flaky_get(url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 10:
+                raise requests.ConnectionError("connection refused")
+            return MagicMock()
+
+        with patch("utils.video.requests.get", side_effect=flaky_get):
+            with self.assertRaises(requests.ConnectionError):
+                download_video("http://example.com/a.mp4", "/tmp/a.mp4")
+        self.assertLessEqual(calls["n"], 5, "retry must be bounded, not retry-until-success")
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self.payload
+
+
+class _FakeSession:
+    """Returns each scripted (payload, status) in turn, repeating the last one."""
+
+    def __init__(self, scripted):
+        self.scripted = list(scripted)
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def _next(self):
+        response = self.scripted[min(self.calls, len(self.scripted) - 1)]
+        self.calls += 1
+        return _FakeResponse(*response)
+
+    def post(self, url, **kwargs):
+        return self._next()
+
+    def get(self, url, **kwargs):
+        return self._next()
+
+
+class TestSeedanceClientBounds(unittest.IsolatedAsyncioTestCase):
+    async def test_create_task_fails_fast_on_auth_error(self):
+        session = _FakeSession([
+            ({"error": "invalid api key"}, 401),
+            ({"error": "invalid api key"}, 401),
+            ({"id": "task-1"}, 200),
+        ])
+        generator = VideoGeneratorDoubaoSeedanceYunwuAPI(api_key="bad-key")
+        with patch("tools.video_generator_doubao_seedance_yunwu_api.aiohttp.ClientSession", return_value=session), \
+             patch("tools.video_generator_doubao_seedance_yunwu_api.asyncio.sleep", new=AsyncMock()):
+            with self.assertRaises(RuntimeError):
+                await generator.create_video_generation_task("a prompt", [])
+        self.assertEqual(session.calls, 1, "4xx must not be retried")
+
+    async def test_query_task_polling_is_bounded(self):
+        session = _FakeSession([({"status": "queued"}, 200)])
+        generator = VideoGeneratorDoubaoSeedanceYunwuAPI(api_key="key", max_poll_attempts=3)
+        with patch("tools.video_generator_doubao_seedance_yunwu_api.aiohttp.ClientSession", return_value=session), \
+             patch("tools.video_generator_doubao_seedance_yunwu_api.asyncio.sleep", new=AsyncMock()):
+            with self.assertRaises(TimeoutError):
+                await generator.query_video_generation_task("task-1")
+        self.assertLessEqual(session.calls, 3)
+
+
+class TestOmniClientBounds(unittest.IsolatedAsyncioTestCase):
+    def test_polling_is_bounded_by_default(self):
+        generator = VideoGeneratorOmniYunwuAPI(api_key="key")
+        self.assertIsNotNone(generator.max_poll_attempts, "default polling must have a deadline")
+
+    async def test_create_task_fails_fast_on_auth_error(self):
+        session = _FakeSession([
+            ({"error": "invalid api key"}, 401),
+            ({"error": "invalid api key"}, 401),
+            ({"id": "task-1"}, 200),
+        ])
+        generator = VideoGeneratorOmniYunwuAPI(api_key="bad-key")
+        with patch("tools.video_generator_omni_yunwu_api.aiohttp.ClientSession", return_value=session), \
+             patch("tools.video_generator_omni_yunwu_api.asyncio.sleep", new=AsyncMock()):
+            with self.assertRaises(RuntimeError):
+                await generator.create_video_generation_task("a prompt", [])
+        self.assertEqual(session.calls, 1, "4xx must not be retried")
+
+
+class TestEventExtractionCap(unittest.TestCase):
+    def test_extraction_aborts_when_model_never_emits_is_last(self):
+        extractor = object.__new__(EventExtractor)
+        calls = {"n": 0}
+
+        def never_last(novel_text, extracted_events):
+            calls["n"] += 1
+            if calls["n"] > 200:
+                raise AssertionError("loop was not capped")
+            return Event(
+                index=len(extracted_events),
+                is_last=False,
+                description="an event",
+                process_chain=["something happens"],
+            )
+
+        extractor.extract_next_event = never_last
+        with self.assertRaisesRegex(RuntimeError, "[Mm]ax|[Cc]ap|exceed"):
+            extractor("some novel text")
+
+    def test_pipeline_extraction_cap_helper(self):
+        _ensure_extraction_cap(0, 50, "events")
+        _ensure_extraction_cap(49, 50, "events")
+        with self.assertRaisesRegex(RuntimeError, "events"):
+            _ensure_extraction_cap(50, 50, "events")
+
+
+class TestCameraTreeValidation(unittest.TestCase):
+    def _camera(self, idx, parent=None):
+        return Camera(idx=idx, active_shot_idxs=[idx], parent_cam_idx=parent, parent_shot_idx=idx if parent is not None else None)
+
+    def test_valid_tree_passes(self):
+        cameras = [self._camera(0), self._camera(1, parent=0), self._camera(2, parent=1)]
+        _validate_camera_tree(cameras)
+
+    def test_cycle_is_rejected(self):
+        cameras = [self._camera(0, parent=1), self._camera(1, parent=0)]
+        with self.assertRaisesRegex(ValueError, "[Cc]ycle"):
+            _validate_camera_tree(cameras)
+
+    def test_self_parent_is_rejected(self):
+        cameras = [self._camera(0, parent=0)]
+        with self.assertRaises(ValueError):
+            _validate_camera_tree(cameras)
+
+    def test_unknown_parent_index_is_rejected(self):
+        cameras = [self._camera(0), self._camera(1, parent=7)]
+        with self.assertRaises(ValueError):
+            _validate_camera_tree(cameras)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/video_generator_doubao_seedance_yunwu_api.py
+++ b/tools/video_generator_doubao_seedance_yunwu_api.py
@@ -13,11 +13,17 @@ class VideoGeneratorDoubaoSeedanceYunwuAPI:
         t2v_model: str = "doubao-seedance-1-0-lite-t2v-250428",
         ff2v_model: str = "doubao-seedance-1-0-lite-i2v-250428",
         flf2v_model: str = "doubao-seedance-1-0-lite-i2v-250428",
+        max_create_attempts: int = 3,
+        poll_interval: int = 2,
+        max_poll_attempts: int = 300,
     ):
         self.api_key = api_key
         self.t2v_model = t2v_model
         self.ff2v_model = ff2v_model
         self.flf2v_model = flf2v_model
+        self.max_create_attempts = max_create_attempts
+        self.poll_interval = poll_interval
+        self.max_poll_attempts = max_poll_attempts
 
 
     async def create_video_generation_task(
@@ -90,21 +96,38 @@ class VideoGeneratorDoubaoSeedanceYunwuAPI:
             'Content-Type': 'application/json'
         }
 
-        while True:
+        last_error = None
+        for attempt in range(1, self.max_create_attempts + 1):
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.post(url, headers=headers, json=payload) as response:
                         response_json = await response.json()
-                        logging.debug(f"Response: {response_json}")
-                        task_id = response_json["id"]
+                        http_status = response.status
+                logging.debug(f"Response: {response_json}")
             except Exception as e:
-                logging.error(f"Error occurred while creating video generation task.\nRetrying in 1 seconds...")
-                await asyncio.sleep(1)
+                last_error = e
+                logging.error(f"Error occurred while creating video generation task (attempt {attempt}/{self.max_create_attempts}): {e}")
+                if attempt < self.max_create_attempts:
+                    await asyncio.sleep(attempt)
                 continue
-            break
 
-        logging.info(f"Video generation task created successfully. Task ID: {task_id}")
-        return task_id
+            if http_status >= 400:
+                message = f"Video generation task creation failed with HTTP {http_status}: {response_json}"
+                if http_status < 500:
+                    raise RuntimeError(message)
+                last_error = RuntimeError(message)
+                logging.error(f"{message} (attempt {attempt}/{self.max_create_attempts})")
+                if attempt < self.max_create_attempts:
+                    await asyncio.sleep(attempt)
+                continue
+
+            task_id = response_json.get("id")
+            if not task_id:
+                raise RuntimeError(f"Video generation task creation returned no task id: {response_json}")
+            logging.info(f"Video generation task created successfully. Task ID: {task_id}")
+            return task_id
+
+        raise RuntimeError(f"Failed to create video generation task after {self.max_create_attempts} attempts.") from last_error
 
     async def query_video_generation_task(
         self,
@@ -124,31 +147,41 @@ class VideoGeneratorDoubaoSeedanceYunwuAPI:
             'Authorization': f'Bearer {self.api_key}',
         }
 
+        attempts = 0
+        consecutive_errors = 0
         while True:
+            if attempts >= self.max_poll_attempts:
+                raise TimeoutError(f"Video generation did not complete after {attempts} polls.")
+            attempts += 1
+
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(url, headers=headers) as response:
                         response_json = await response.json()
-
+                        http_status = response.status
             except Exception as e:
-                logging.error(f"Error occurred while querying video generation task: {e}. Retrying in 1 seconds...")
-                await asyncio.sleep(1)
+                consecutive_errors += 1
+                if consecutive_errors >= 5:
+                    raise RuntimeError(f"Querying video generation task failed {consecutive_errors} times in a row.") from e
+                logging.error(f"Error occurred while querying video generation task: {e}. Retrying in {self.poll_interval} seconds...")
+                await asyncio.sleep(self.poll_interval)
                 continue
+            consecutive_errors = 0
 
-            status = response_json["status"]
+            if http_status >= 400:
+                raise RuntimeError(f"Querying video generation task failed with HTTP {http_status}: {response_json}")
+
+            status = response_json.get("status")
             if status == "succeeded":
                 video_url = response_json["content"]["video_url"]
                 logging.info(f"Video generation completed successfully. Video URL: {video_url}")
-                break
+                return video_url
             elif status == "failed":
                 logging.error(f"Video generation failed. Response: {response_json}")
                 raise ValueError("Video generation failed.")
             else:
-                logging.info(f"Video generation is still in progress. Checking again in 2 seconds...")
-                await asyncio.sleep(2)
-                continue
-
-        return video_url
+                logging.info(f"Video generation is still in progress. Checking again in {self.poll_interval} seconds...")
+                await asyncio.sleep(self.poll_interval)
 
     async def generate_single_video(
         self,

--- a/tools/video_generator_omni_yunwu_api.py
+++ b/tools/video_generator_omni_yunwu_api.py
@@ -20,7 +20,8 @@ class VideoGeneratorOmniYunwuAPI:
         enable_upsample: bool = False,
         enable_sample: Optional[bool] = None,
         poll_interval: int = 2,
-        max_poll_attempts: Optional[int] = None,
+        max_poll_attempts: Optional[int] = 300,
+        max_create_attempts: int = 3,
         rate_limiter: Optional[RateLimiter] = None,
     ):
         self.api_key = api_key
@@ -32,6 +33,7 @@ class VideoGeneratorOmniYunwuAPI:
         self.enable_sample = enable_sample
         self.poll_interval = poll_interval
         self.max_poll_attempts = max_poll_attempts
+        self.max_create_attempts = max_create_attempts
         self.rate_limiter = rate_limiter
 
     def _headers(self) -> dict:
@@ -111,22 +113,45 @@ class VideoGeneratorOmniYunwuAPI:
             await self.rate_limiter.acquire()
 
         url = f"{self.base_url}/v1/video/create"
-        while True:
+        last_error = None
+        for attempt in range(1, self.max_create_attempts + 1):
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.post(url, headers=self._headers(), json=payload) as response:
                         response_json = await response.json()
+                        http_status = response.status
                 logging.debug("Response: %s", response_json)
-
-                task_id = response_json["id"]
-                logging.info("Video generation task created successfully. Task ID: %s", task_id)
-                return task_id, payload["model"]
             except Exception as e:
+                last_error = e
                 logging.error(
-                    "Error occurred while creating video generation task: %s. Retrying in 1 second...",
+                    "Error occurred while creating video generation task (attempt %s/%s): %s",
+                    attempt,
+                    self.max_create_attempts,
                     e,
                 )
-                await asyncio.sleep(1)
+                if attempt < self.max_create_attempts:
+                    await asyncio.sleep(attempt)
+                continue
+
+            if http_status >= 400:
+                message = f"Video generation task creation failed with HTTP {http_status}: {response_json}"
+                if http_status < 500:
+                    raise RuntimeError(message)
+                last_error = RuntimeError(message)
+                logging.error("%s (attempt %s/%s)", message, attempt, self.max_create_attempts)
+                if attempt < self.max_create_attempts:
+                    await asyncio.sleep(attempt)
+                continue
+
+            task_id = response_json.get("id")
+            if not task_id:
+                raise RuntimeError(f"Video generation task creation returned no task id: {response_json}")
+            logging.info("Video generation task created successfully. Task ID: %s", task_id)
+            return task_id, payload["model"]
+
+        raise RuntimeError(
+            f"Failed to create video generation task after {self.max_create_attempts} attempts."
+        ) from last_error
 
     async def query_video_generation_task(self, task_id: str, model: str) -> str:
         url = f"{self.base_url}/v1/video/query"

--- a/utils/image.py
+++ b/utils/image.py
@@ -2,17 +2,18 @@ import logging
 import requests
 import base64
 import mimetypes
-from tenacity import retry
 from io import BytesIO
 import cv2
 
+from utils.retry import download_retry
 
-@retry
+
+@download_retry
 def download_image(url, save_path):
     try:
         logging.info(f"Downloading image from {url} to {save_path}")
 
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, timeout=(10, 300))
         response.raise_for_status() # Check for HTTP errors
 
         with open(save_path, 'wb') as file:

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -2,8 +2,28 @@ import tenacity
 import traceback
 import logging
 
+import requests
+
 def after_func(retry_state: tenacity.RetryCallState) -> None:
     if retry_state.outcome.failed:
         exc = retry_state.outcome.exception()
         logging.warning(f"Retrying {retry_state.fn.__name__} due to {repr(exc)} (Attempt {retry_state.attempt_number})")
         logging.debug(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+
+def is_retryable_download_error(exc: BaseException) -> bool:
+    """Network errors and 5xx responses are retryable; other HTTP errors (expired
+    or invalid URLs, auth failures) will never succeed and must fail fast."""
+    if isinstance(exc, requests.HTTPError):
+        response = exc.response
+        return response is None or response.status_code >= 500
+    return isinstance(exc, requests.RequestException)
+
+
+download_retry = tenacity.retry(
+    stop=tenacity.stop_after_attempt(3),
+    wait=tenacity.wait_exponential(multiplier=1, max=10),
+    retry=tenacity.retry_if_exception(is_retryable_download_error),
+    after=after_func,
+    reraise=True,
+)

--- a/utils/video.py
+++ b/utils/video.py
@@ -1,14 +1,14 @@
 import logging
 import requests
-from tenacity import retry
+from utils.retry import download_retry
 
 
-@retry
+@download_retry
 def download_video(url, save_path):
     try:
         logging.info(f"Downloading video from {url} to {save_path}")
 
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, timeout=(10, 300))
         response.raise_for_status()  # 检查请求是否成功
     
         with open(save_path, 'wb') as f:


### PR DESCRIPTION
## Summary

Several failure paths previously hung forever (or spent tokens without bound) instead of surfacing an error:

- **`utils/image.py` / `utils/video.py`** — `download_image`/`download_video` used bare `@retry` (tenacity: retry forever, zero wait) around a `requests.get` with no timeout, so an expired signed URL became an infinite hot loop. Now: 3 attempts, exponential backoff, fail-fast on 4xx, connect/read timeouts (shared policy in `utils/retry.py`).
- **`tools/video_generator_doubao_seedance_yunwu_api.py`** — task creation retried every second forever on any exception (a bad API key never surfaced; the exception wasn't even included in the log message), and polling had no deadline. Now checks HTTP status, fails fast on 4xx, bounds create retries, and polls with a deadline plus a consecutive-error cap.
- **`tools/video_generator_omni_yunwu_api.py`** — same unbounded create loop, fixed the same way; the poll deadline now defaults to 300 instead of unbounded `None`.
- **`agents/event_extractor.py` / `pipelines/novel2movie_pipeline.py`** — event/scene extraction looped on the LLM-asserted `is_last` flag with no cap; a model that never sets it spent tokens forever. Hard caps now abort with a clear error.
- **`agents/camera_image_generator.py`** — `construct_camera_tree` accepted whatever parent graph the LLM emitted; a cycle deadlocked frame generation forever (cameras awaiting events only their descendants would set), with no error. The tree is now validated for length, unknown parents, self-parents, and cycles. Also removes a duplicated `parent_shot_idx` assignment.

## Test plan

`uv run --with pytest python -m pytest tests/` — 116 passed (102 existing + 14 new in `tests/test_hang_guards.py`). The new tests' fakes succeed after N calls, so the fixed code must give up before the fake would have succeeded — they fail fast against the old behavior instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)