### PR TITLE
Fix silent wrong-output bugs in the script2video render path

### DIFF
--- a/agents/reference_image_selector.py
+++ b/agents/reference_image_selector.py
@@ -178,7 +178,7 @@ class ReferenceImageSelector:
 
             try:
                 ref = await chain.ainvoke(messages)
-                filtered_image_path_and_text_pairs = [available_image_path_and_text_pairs[i] for i in ref.ref_image_indices]
+                filtered_image_path_and_text_pairs = select_pairs_by_indices(available_image_path_and_text_pairs, ref.ref_image_indices)
                 logging.info(f"Filtered image idx:{ref.ref_image_indices}")
                 
             except Exception as e:
@@ -211,8 +211,8 @@ class ReferenceImageSelector:
         chain = self.chat_model | parser
 
         try:
-            response = await chain.ainvoke(messages)        
-            reference_image_path_and_text_pairs = [filtered_image_path_and_text_pairs[i] for i in response.ref_image_indices]
+            response = await chain.ainvoke(messages)
+            reference_image_path_and_text_pairs = select_pairs_by_indices(filtered_image_path_and_text_pairs, response.ref_image_indices)
             return {
                 "reference_image_path_and_text_pairs": reference_image_path_and_text_pairs,
                 "text_prompt": response.text_prompt,
@@ -223,3 +223,14 @@ class ReferenceImageSelector:
             raise e
 
 
+
+
+def select_pairs_by_indices(pairs, indices):
+    """Index into pairs with LLM-emitted indices, rejecting out-of-range values.
+
+    Negative indices would silently select the wrong image via Python indexing.
+    """
+    invalid = [i for i in indices if i < 0 or i >= len(pairs)]
+    if invalid:
+        raise ValueError(f"ref_image_indices out of range: {invalid} (have {len(pairs)} images)")
+    return [pairs[i] for i in indices]

--- a/agents/storyboard_artist.py
+++ b/agents/storyboard_artist.py
@@ -241,6 +241,9 @@ class StoryboardArtist:
             timeout=retry_timeout,
         )
 
+        validate_char_idxs(decomposition.ff_vis_char_idxs, len(characters), "ff_vis_char_idxs")
+        validate_char_idxs(decomposition.lf_vis_char_idxs, len(characters), "lf_vis_char_idxs")
+
         return ShotDescription(
             idx=shot_brief_desc.idx,
             is_last=shot_brief_desc.is_last,
@@ -254,4 +257,19 @@ class StoryboardArtist:
             lf_vis_char_idxs=decomposition.lf_vis_char_idxs,
             motion_desc=decomposition.motion_desc,
             audio_desc=shot_brief_desc.audio_desc,
+        )
+
+
+def validate_char_idxs(idxs, num_characters, field_name):
+    """Reject LLM-emitted character indices outside [0, num_characters).
+
+    Negative values would silently select the wrong character via Python
+    indexing; out-of-range values would crash deep inside the render gather.
+    Raising here lets the @retry on decompose_visual_description re-ask.
+    """
+    invalid = [idx for idx in idxs if idx < 0 or idx >= num_characters]
+    if invalid:
+        raise ValueError(
+            f"{field_name} contains invalid character indices {invalid}; "
+            f"valid range is 0..{num_characters - 1}"
         )

--- a/pipelines/idea2video_pipeline.py
+++ b/pipelines/idea2video_pipeline.py
@@ -11,6 +11,7 @@ import yaml
 from langchain.chat_models import init_chat_model
 from tools.render_backend import RenderBackend
 from utils.provider_presets import resolve_chat_model_config
+from utils.text import safe_path_component
 
 
 def _pipeline_print(quiet: bool, message: str) -> None:
@@ -156,7 +157,7 @@ class Idea2VideoPipeline:
         style: str,
     ):
         character_dir = os.path.join(
-            self.working_dir, "character_portraits", f"{character.idx}_{character.identifier_in_scene}")
+            self.working_dir, "character_portraits", f"{character.idx}_{safe_path_component(character.identifier_in_scene)}")
         os.makedirs(character_dir, exist_ok=True)
 
         front_portrait_path = os.path.join(character_dir, "front.png")

--- a/pipelines/novel2movie_pipeline.py
+++ b/pipelines/novel2movie_pipeline.py
@@ -22,6 +22,8 @@ from interfaces import (
 )
 from tenacity import retry
 
+from utils.text import safe_path_component
+
 
 
 def _pipeline_print(quiet: bool, message: str) -> None:
@@ -386,7 +388,7 @@ class Novel2MoviePipeline:
 
         async def generate_base_portrait(sem, character: CharacterInNovel):
             async with sem:
-                image_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{character.identifier_in_novel}.png")
+                image_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{safe_path_component(character.identifier_in_novel)}.png")
                 if os.path.exists(image_path):
                     return image_path
                 prompt = f"Generate a full-body, front-view portrait based on the following description, in the style of {style}:"
@@ -403,7 +405,7 @@ class Novel2MoviePipeline:
 
         async def generate_scene_portrait(sem, base_character_image_path: str, character: CharacterInScene, event_idx: int, scene_idx: int):
             async with sem:
-                image_path = os.path.join(working_dir_character_portrait, f"event_{event_idx}", f"scene_{scene_idx}", f"character_{character.idx}_{character.identifier_in_scene}.png")
+                image_path = os.path.join(working_dir_character_portrait, f"event_{event_idx}", f"scene_{scene_idx}", f"character_{character.idx}_{safe_path_component(character.identifier_in_scene)}.png")
                 os.makedirs(os.path.dirname(image_path), exist_ok=True)
                 if os.path.exists(image_path):
                     return image_path
@@ -423,7 +425,7 @@ class Novel2MoviePipeline:
         scene_portrait_tasks = []
         sem = asyncio.Semaphore(3)
         for character in characters_in_novel:
-            base_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{character.identifier_in_novel}.png")
+            base_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{safe_path_component(character.identifier_in_novel)}.png")
             for event_idx, identifier_in_event in character.active_events.items():
                 event_characters = event_idx_to_characters_in_event[int(event_idx)]
                 character_in_event = [char for char in event_characters if char.identifier_in_event == identifier_in_event][0]
@@ -447,7 +449,7 @@ class Novel2MoviePipeline:
                 for character in scene.characters:
                     character_portraits_registry[character.identifier_in_scene] = {
                         "portrait": {
-                            "path": os.path.join(working_dir_character_portrait, f"event_{event.index}", f"scene_{scene.idx}", f"character_{character.idx}_{character.identifier_in_scene}.png"),
+                            "path": os.path.join(working_dir_character_portrait, f"event_{event.index}", f"scene_{scene.idx}", f"character_{character.idx}_{safe_path_component(character.identifier_in_scene)}.png"),
                             "description": f"A portrait of {character.identifier_in_scene}",
                         }
                     }
@@ -852,7 +854,7 @@ class Novel2MoviePipeline:
 
         async def generate_portrait_for_character(sem, character: CharacterInNovel):
             async with sem:
-                image_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{character.identifier_in_novel}.png")
+                image_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{safe_path_component(character.identifier_in_novel)}.png")
                 
                 if os.path.exists(image_path):
                     print(f"⏭️ Skipping portrait generation for character {character.idx} as it already exists.")
@@ -933,7 +935,7 @@ class Novel2MoviePipeline:
         sem = asyncio.Semaphore(3)
         tasks = []
         for character in characters_in_novel:
-            character_base_image_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{character.identifier_in_novel}.png")
+            character_base_image_path = os.path.join(base_character_portrait_dir, f"character_{character.index}_{safe_path_component(character.identifier_in_novel)}.png")
             for event_idx, identifier_in_event in character.active_events.items():
                 characters_in_event: List[CharacterInEvent] = event_idx_to_characters_in_event[event_idx]
                 character_in_event = [char for char in characters_in_event if char.identifier_in_event == identifier_in_event][0]  # TODO: 这里的数据结构没有做好，居然还要遍历查找。。。

--- a/pipelines/script2video_pipeline.py
+++ b/pipelines/script2video_pipeline.py
@@ -13,6 +13,7 @@ from interfaces import *
 from langchain.chat_models import init_chat_model
 from tools.render_backend import RenderBackend
 from utils.provider_presets import resolve_chat_model_config
+from utils.text import safe_path_component
 
 
 def _pipeline_print(quiet: bool, message: str) -> None:
@@ -44,12 +45,6 @@ def _scoped_progress(progress, **scope):
 
 class Script2VideoPipeline:
 
-    # events
-    character_portrait_events = {}
-    shot_desc_events = {}
-    frame_events = {}
-
-
     def __init__(
         self,
         chat_model: str,
@@ -57,6 +52,12 @@ class Script2VideoPipeline:
         video_generator,
         working_dir: str,
     ):
+        # Per-instance coordination events; these were once class attributes,
+        # which leaked shot/frame state across scenes when one pipeline object
+        # (or several) rendered more than one scene.
+        self.character_portrait_events = {}
+        self.shot_desc_events = {}
+        self.frame_events = {}
 
         self.chat_model = chat_model
         self.image_generator = image_generator
@@ -156,6 +157,9 @@ class Script2VideoPipeline:
         progress: Callable[[str, str, Dict[str, Any] | None], None] | None = None,
     ):
         _emit_render_progress(progress, "render_start", "Starting script2video render")
+        self.character_portrait_events = {}
+        self.shot_desc_events = {}
+        self.frame_events = {}
         if characters is None:
             _emit_render_progress(progress, "extract_characters", "Extracting characters before render")
             characters = await self.extract_characters(script=script, quiet=quiet)
@@ -227,7 +231,7 @@ class Script2VideoPipeline:
         )
         _emit_render_progress(progress, "camera_tree_ready", "Camera tree ready", {"camera_count": len(camera_tree)})
 
-        priority_shot_idxs = [camera.parent_cam_idx for camera in camera_tree if camera.parent_cam_idx is not None]
+        priority_shot_idxs = _collect_priority_shot_idxs(camera_tree)
         _emit_render_progress(progress, "frames_start", "Generating frames for cameras", {"camera_count": len(camera_tree), "shot_count": len(shot_descriptions)})
         tasks = [
             self.generate_frames_for_single_camera(
@@ -338,12 +342,16 @@ class Script2VideoPipeline:
                     print(f"☑️ Generated new camera image for shot {first_shot_idx} (not completed), saved to {new_camera_image_path}.")
                     _emit_render_progress(progress, "new_camera_image_done", f"New camera image for shot {first_shot_idx} extracted", {"camera_idx": camera.idx, "shot_idx": first_shot_idx, "path": new_camera_image_path})
 
-                    available_image_path_and_text_pairs.append(
-                        (
-                            new_camera_image_path,
-                            f"The composition and background are correct but some elements may be wrong. The wrong elements should be replaced.\nWrong elements: {camera.missing_info}.\nYou must select this image as the main reference and replace the characters in the image with the provided character portraits. Don't change the background."
-                        )
+                # Offer the new-camera image regardless of whether it was just
+                # generated or already on disk: when this sat in the else branch
+                # above, resumed runs silently dropped the key composition
+                # reference and produced different frames than fresh runs.
+                available_image_path_and_text_pairs.append(
+                    (
+                        new_camera_image_path,
+                        f"The composition and background are correct but some elements may be wrong. The wrong elements should be replaced.\nWrong elements: {camera.missing_info}.\nYou must select this image as the main reference and replace the characters in the image with the provided character portraits. Don't change the background."
                     )
+                )
 
 
             # 如果子镜头缺少信息，则需要选择参考图像生成
@@ -553,12 +561,7 @@ class Script2VideoPipeline:
             _pipeline_print(quiet, f"🚀 Loaded {len(camera_tree)} cameras from existing file.")
             return camera_tree
 
-        cameras: List[Camera] = []
-        for shot_description in shot_descriptions:
-            if shot_description.cam_idx not in [camera.idx for camera in cameras]:
-                cameras.append(Camera(idx=shot_description.cam_idx, active_shot_idxs=[shot_description.idx]))
-            else:
-                cameras[shot_description.cam_idx].active_shot_idxs.append(shot_description.idx)
+        cameras = _group_shots_into_cameras(shot_descriptions)
 
         camera_tree = await self.camera_image_generator.construct_camera_tree(cameras=cameras, shot_descs=shot_descriptions)
         with open(camera_tree_path, "w", encoding="utf-8") as f:
@@ -634,7 +637,7 @@ class Script2VideoPipeline:
         style: str,
         progress: Callable[[str, str, Dict[str, Any] | None], None] | None = None,
     ):
-        character_dir = os.path.join(self.working_dir, "character_portraits", f"{character.idx}_{character.identifier_in_scene}")
+        character_dir = os.path.join(self.working_dir, "character_portraits", f"{character.idx}_{safe_path_component(character.identifier_in_scene)}")
         os.makedirs(character_dir, exist_ok=True)
         _emit_render_progress(progress, "character_portrait_start", f"Generating portraits for {character.identifier_in_scene}", {"character_idx": character.idx, "identifier": character.identifier_in_scene})
 
@@ -773,3 +776,29 @@ class Script2VideoPipeline:
             }
 
         return shot_description
+
+
+def _group_shots_into_cameras(shot_descriptions: List[ShotDescription]) -> List[Camera]:
+    """Group shots by their camera index.
+
+    Cameras are looked up by their idx field, not by list position: cameras are
+    appended in order of first appearance, so positional indexing would attach
+    shots to the wrong camera whenever the LLM emits cam indices out of order.
+    """
+    cameras: List[Camera] = []
+    cameras_by_idx: Dict[int, Camera] = {}
+    for shot_description in shot_descriptions:
+        camera = cameras_by_idx.get(shot_description.cam_idx)
+        if camera is None:
+            camera = Camera(idx=shot_description.cam_idx, active_shot_idxs=[shot_description.idx])
+            cameras_by_idx[shot_description.cam_idx] = camera
+            cameras.append(camera)
+        else:
+            camera.active_shot_idxs.append(shot_description.idx)
+    return cameras
+
+
+def _collect_priority_shot_idxs(camera_tree: List[Camera]) -> List[int]:
+    """Shot indices that other cameras depend on (compared against shot idxs, so
+    they must come from parent_shot_idx, not the camera index space)."""
+    return [camera.parent_shot_idx for camera in camera_tree if camera.parent_shot_idx is not None]

--- a/tests/test_wrong_output_guards.py
+++ b/tests/test_wrong_output_guards.py
@@ -1,0 +1,184 @@
+"""Regression tests for silent wrong-output bugs in the script2video render path."""
+
+import asyncio
+import os
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from agents.reference_image_selector import select_pairs_by_indices
+from agents.storyboard_artist import validate_char_idxs
+from interfaces.camera import Camera
+from interfaces.shot_description import ShotDescription
+from pipelines.script2video_pipeline import (
+    Script2VideoPipeline,
+    _collect_priority_shot_idxs,
+    _group_shots_into_cameras,
+)
+from utils.text import safe_path_component
+
+
+def _shot(idx, cam_idx, variation_type="small", ff_chars=None, lf_chars=None):
+    return ShotDescription(
+        idx=idx,
+        is_last=False,
+        cam_idx=cam_idx,
+        visual_desc=f"shot {idx}",
+        variation_type=variation_type,
+        variation_reason="r",
+        ff_desc=f"first frame {idx}",
+        ff_vis_char_idxs=ff_chars or [],
+        lf_desc=f"last frame {idx}",
+        lf_vis_char_idxs=lf_chars or [],
+        motion_desc="m",
+        audio_desc="a",
+    )
+
+
+class TestCameraGrouping(unittest.TestCase):
+    def test_out_of_order_camera_indices_group_correctly(self):
+        # Shot 0 uses camera 1, shot 1 uses camera 0, shot 2 uses camera 1 again.
+        shots = [_shot(0, cam_idx=1), _shot(1, cam_idx=0), _shot(2, cam_idx=1)]
+        cameras = _group_shots_into_cameras(shots)
+        by_idx = {camera.idx: camera for camera in cameras}
+        self.assertEqual(by_idx[1].active_shot_idxs, [0, 2])
+        self.assertEqual(by_idx[0].active_shot_idxs, [1])
+
+
+class TestPriorityShotIdxs(unittest.TestCase):
+    def test_priorities_are_shot_indices_not_camera_indices(self):
+        # Camera 2 depends on shot 7 of camera 0: shot 7 must be prioritized.
+        camera_tree = [
+            Camera(idx=0, active_shot_idxs=[7, 8]),
+            Camera(idx=2, active_shot_idxs=[9], parent_cam_idx=0, parent_shot_idx=7),
+        ]
+        self.assertEqual(_collect_priority_shot_idxs(camera_tree), [7])
+
+
+class TestEventDictsAreInstanceState(unittest.TestCase):
+    def _pipeline(self, working_dir):
+        return Script2VideoPipeline(
+            chat_model=MagicMock(),
+            image_generator=MagicMock(),
+            video_generator=MagicMock(),
+            working_dir=working_dir,
+        )
+
+    def test_two_pipelines_do_not_share_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p1 = self._pipeline(os.path.join(tmp, "a"))
+            p2 = self._pipeline(os.path.join(tmp, "b"))
+            p1.frame_events[0] = {"first_frame": asyncio.Event()}
+            p1.shot_desc_events[0] = asyncio.Event()
+            p1.character_portrait_events[0] = asyncio.Event()
+            self.assertEqual(p2.frame_events, {})
+            self.assertEqual(p2.shot_desc_events, {})
+            self.assertEqual(p2.character_portrait_events, {})
+
+    def test_no_class_level_mutable_event_dicts(self):
+        for name in ("frame_events", "shot_desc_events", "character_portrait_events"):
+            self.assertNotIsInstance(
+                Script2VideoPipeline.__dict__.get(name), dict,
+                f"{name} must not be shared class state",
+            )
+
+
+class TestResumeIncludesNewCameraReference(unittest.IsolatedAsyncioTestCase):
+    async def test_existing_new_camera_image_is_still_offered_to_selector(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = Script2VideoPipeline(
+                chat_model=MagicMock(),
+                image_generator=MagicMock(),
+                video_generator=MagicMock(),
+                working_dir=tmp,
+            )
+            shots = [_shot(0, cam_idx=0), _shot(1, cam_idx=1)]
+            camera = Camera(
+                idx=1, active_shot_idxs=[1],
+                parent_cam_idx=0, parent_shot_idx=0,
+                missing_info="wrong background",
+            )
+            parent_done = asyncio.Event()
+            parent_done.set()
+            pipeline.frame_events = {
+                0: {"first_frame": parent_done},
+                1: {"first_frame": asyncio.Event()},
+            }
+
+            # Resume state: transition video and new-camera image already on disk.
+            shot_dir = os.path.join(tmp, "shots", "1")
+            os.makedirs(shot_dir, exist_ok=True)
+            new_camera_path = os.path.join(shot_dir, "new_camera_1.png")
+            open(os.path.join(shot_dir, "transition_video_from_shot_0.mp4"), "wb").close()
+            open(new_camera_path, "wb").close()
+
+            selector = AsyncMock(return_value={"reference_image_path_and_text_pairs": [], "text_prompt": "p"})
+            pipeline.reference_image_selector = MagicMock(select_reference_images_and_generate_prompt=selector)
+            fake_image = MagicMock()
+            pipeline.image_generator.generate_single_image = AsyncMock(return_value=fake_image)
+
+            await pipeline.generate_frames_for_single_camera(
+                camera=camera,
+                shot_descriptions=shots,
+                characters=[],
+                character_portraits_registry={},
+                priority_shot_idxs=[],
+            )
+
+            selector.assert_awaited_once()
+            offered = selector.await_args.kwargs["available_image_path_and_text_pairs"]
+            offered_paths = [pair[0] for pair in offered]
+            self.assertIn(new_camera_path, offered_paths,
+                          "resumed runs must offer the new-camera reference image to the selector")
+
+
+class TestCharIdxValidation(unittest.TestCase):
+    def test_valid_indices_pass(self):
+        validate_char_idxs([0, 1], 2, "ff_vis_char_idxs")
+
+    def test_out_of_range_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_char_idxs([0, 2], 2, "ff_vis_char_idxs")
+
+    def test_negative_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_char_idxs([-1], 2, "lf_vis_char_idxs")
+
+
+class TestReferenceSelectorIndices(unittest.TestCase):
+    def test_valid_selection(self):
+        pairs = [("a.png", "a"), ("b.png", "b")]
+        self.assertEqual(select_pairs_by_indices(pairs, [1]), [("b.png", "b")])
+
+    def test_negative_index_rejected(self):
+        with self.assertRaises(ValueError):
+            select_pairs_by_indices([("a.png", "a")], [-1])
+
+    def test_out_of_range_rejected(self):
+        with self.assertRaises(ValueError):
+            select_pairs_by_indices([("a.png", "a")], [3])
+
+
+class TestSafePathComponent(unittest.TestCase):
+    def test_clean_names_unchanged(self):
+        self.assertEqual(safe_path_component("Alice"), "Alice")
+        self.assertEqual(safe_path_component("Bob_2"), "Bob_2")
+
+    def test_unicode_names_preserved(self):
+        self.assertEqual(safe_path_component("李雷"), "李雷")
+
+    def test_path_separators_removed(self):
+        self.assertNotIn("/", safe_path_component("a/b"))
+        self.assertNotIn("\\", safe_path_component("a\\b"))
+
+    def test_traversal_neutralized(self):
+        cleaned = safe_path_component("../../etc/passwd")
+        self.assertNotIn("/", cleaned)
+        self.assertFalse(cleaned.startswith("."))
+
+    def test_empty_becomes_placeholder(self):
+        self.assertEqual(safe_path_component(""), "unnamed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/text.py
+++ b/utils/text.py
@@ -1,0 +1,14 @@
+import re
+
+
+def safe_path_component(name) -> str:
+    """Sanitize an LLM-derived identifier for use as a filesystem path component.
+
+    Identifiers come from model output over user-supplied story text, so they may
+    contain separators or traversal sequences; keep word characters (including
+    CJK), dashes, dots and spaces, replace everything else, and strip leading
+    dots so the result can never escape or hide within the working directory.
+    """
+    cleaned = re.sub(r"[^\w\-. ]", "_", str(name))
+    cleaned = cleaned.strip().lstrip(".")
+    return cleaned or "unnamed"


### PR DESCRIPTION
## Summary

Bugs that complete successfully but corrupt the output, plus validation of LLM-emitted indices/identifiers before they become program state:

- **Camera grouping** (`construct_camera_tree`) indexed the cameras list positionally by `cam_idx` even though cameras are stored in first-appearance order, silently attaching shots to the wrong camera whenever the LLM emits cam indices out of order. Cameras are now looked up by their `idx` field.
- **Shot prioritization** collected `parent_cam_idx` (camera index space) but compared it against shot indices, so parent shots were never actually prioritized and dependent cameras stalled. It now collects `parent_shot_idx`.
- **`character_portrait_events`/`shot_desc_events`/`frame_events` were class attributes** shared by every `Script2VideoPipeline` instance and never reset by `__call__`, leaking shot/frame state across scenes (novel2movie reuses one pipeline object per scene). They are instance state now, reset per render.
- **Resume path**: the new-camera reference image append sat inside the generation else-branch, so resumed runs silently dropped the key composition reference and rendered visibly different frames than fresh runs.
- **LLM-emitted indices** (`ff/lf_vis_char_idxs`, `ref_image_indices`) are now range-validated; negative values previously selected the wrong character/image silently via Python negative indexing, and out-of-range values crashed deep inside the render gather. Raising inside the retried parse steps lets the existing `@retry` re-ask the model.
- **LLM-derived character identifiers are sanitized** (`utils/text.safe_path_component`, CJK-preserving) before use as filesystem path components — they come from model output over user-supplied story text and could contain separators or traversal sequences. Clean identifiers produce identical paths to before.

## Test plan

`uv run --with pytest python -m pytest tests/` — 118 passed (102 existing + 16 new in `tests/test_wrong_output_guards.py`), including a behavioral test that renders a camera in resume state and asserts the selector is offered the new-camera reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)