### PR TITLE
Add error boundaries, durable session persistence, and bounded retry policies

### DIFF
--- a/agent_runtime/llm.py
+++ b/agent_runtime/llm.py
@@ -1,14 +1,33 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
 
-from openai import AsyncOpenAI
+from openai import APIConnectionError, APITimeoutError, AsyncOpenAI
 
 from .config import llm_api_key, llm_base_url, llm_model
 from .models import ToolCall
+
+LLM_MAX_ATTEMPTS = 3
+LLM_RETRY_BACKOFF_SECONDS = (1.0, 4.0)
+LLM_REQUEST_TIMEOUT_SECONDS = 300.0
+
+
+def _is_retryable_llm_error(exc: BaseException) -> bool:
+    """Rate limits, server errors, and connection problems are transient;
+    auth/validation errors will never succeed and must surface immediately."""
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        try:
+            status = int(status)
+        except (TypeError, ValueError):
+            return False
+        return status == 429 or status >= 500
+    return isinstance(exc, (APIConnectionError, APITimeoutError))
 
 
 @dataclass(slots=True)
@@ -25,10 +44,21 @@ class OpenAICompatibleLLM:
         self.api_key = api_key or llm_api_key()
         if not self.api_key:
             raise RuntimeError("VIMAX_LLM_API_KEY is required for the agent LLM client")
-        self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
+        self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url, timeout=LLM_REQUEST_TIMEOUT_SECONDS)
 
     async def complete(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> AssistantMessage:
-        response = await self.client.chat.completions.create(model=self.model, messages=messages, tools=tools or None, tool_choice="auto" if tools else None)
+        for attempt in range(LLM_MAX_ATTEMPTS):
+            try:
+                response = await self.client.chat.completions.create(model=self.model, messages=messages, tools=tools or None, tool_choice="auto" if tools else None)
+                break
+            except Exception as exc:
+                if attempt == LLM_MAX_ATTEMPTS - 1 or not _is_retryable_llm_error(exc):
+                    raise
+                delay = LLM_RETRY_BACKOFF_SECONDS[min(attempt, len(LLM_RETRY_BACKOFF_SECONDS) - 1)]
+                logging.warning("LLM call failed (%s); retrying in %.1fs (attempt %d/%d)", exc, delay, attempt + 1, LLM_MAX_ATTEMPTS)
+                await asyncio.sleep(delay)
+        if not response.choices:
+            raise RuntimeError("LLM response contained no choices (content filter or relay error)")
         message = response.choices[0].message
         text = message.content or ""
         calls: list[ToolCall] = []

--- a/agent_runtime/loop.py
+++ b/agent_runtime/loop.py
@@ -67,7 +67,16 @@ class AgentLoop:
 
         while True:
             yield {"type": "status", "turn_id": control.turn_id, "phase": "sampling_assistant", "message": "Sampling assistant"}
-            assistant = await self.llm.complete(runtime_messages, tools=tool_schemas)
+            try:
+                assistant = await self.llm.complete(runtime_messages, tools=tool_schemas)
+            except Exception as exc:
+                # Without this boundary a single API failure propagated out of the
+                # generator: the turn record was never persisted and the CLI died.
+                status = "failed"
+                final_text = f"LLM call failed: {exc}"
+                transitions.append(_transition("sampling_assistant", "finalizing_answer", "llm_error"))
+                yield {"type": "error", "turn_id": control.turn_id, "message": final_text}
+                break
             assistant_turns.append({"phase": "initial" if tool_round == 0 else f"followup_{tool_round}", "text": assistant.text, "tool_calls": [call.as_dict() for call in assistant.tool_calls]})
             if not assistant.tool_calls:
                 transitions.append(_transition("sampling_assistant", "finalizing_answer", "assistant_finished_without_tools"))

--- a/agent_runtime/session_index.py
+++ b/agent_runtime/session_index.py
@@ -1,13 +1,38 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import re
+from contextlib import contextmanager
 from datetime import datetime
+from functools import wraps
 from pathlib import Path
 from typing import Any
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    fcntl = None
+
 
 STALE_KEYS = ["story", "characters", "script", "storyboard", "shot_descriptions", "camera_tree", "frames", "clips", "final_video"]
+
+
+def _synchronized(method):
+    """Hold the index file lock across a read-modify-write cycle.
+
+    Every mutator loads the whole sessions file, edits it, and saves it back;
+    without a lock, two concurrent writers (threads or processes) silently
+    drop each other's updates.
+    """
+
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._locked():
+            return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 class SessionIndex:
@@ -26,14 +51,40 @@ class SessionIndex:
         if not self.sessions_path.exists():
             self.save({"active_session_id": "", "sessions": {}})
 
+    @contextmanager
+    def _locked(self):
+        if fcntl is None:
+            yield
+            return
+        lock_path = self.vimax_dir / "sessions.lock"
+        with open(lock_path, "a+", encoding="utf-8") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle, fcntl.LOCK_UN)
+
     def load(self) -> dict[str, Any]:
         try:
             return json.loads(self.sessions_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, FileNotFoundError):
+        except FileNotFoundError:
+            return {"active_session_id": "", "sessions": {}}
+        except json.JSONDecodeError:
+            # A corrupt file usually means a crash mid-write. Returning empty
+            # state is fine for this call, but the next save() would overwrite
+            # the file and destroy every session — keep the evidence first.
+            backup = self.sessions_path.with_name(f"sessions.json.corrupt-{datetime.now().strftime('%Y%m%d-%H%M%S-%f')}")
+            try:
+                os.replace(self.sessions_path, backup)
+                logging.error("sessions.json was corrupt; preserved it at %s and starting with empty state", backup)
+            except OSError:
+                logging.error("sessions.json is corrupt and could not be backed up; starting with empty state")
             return {"active_session_id": "", "sessions": {}}
 
     def save(self, data: dict[str, Any]) -> None:
-        self.sessions_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp_path = self.sessions_path.with_name("sessions.json.tmp")
+        tmp_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp_path, self.sessions_path)
 
     def active(self) -> dict[str, Any] | None:
         data = self.load()
@@ -48,6 +99,7 @@ class SessionIndex:
         record = self.load().get("sessions", {}).get(normalized)
         return self._with_session_defaults(record) if isinstance(record, dict) else None
 
+    @_synchronized
     def create(self, idea: str = "", user_requirement: str = "", style: str = "", session_id: str | None = None) -> dict[str, Any]:
         data = self.load()
         sessions = data.setdefault("sessions", {})
@@ -87,6 +139,7 @@ class SessionIndex:
             return active
         return self.create(idea=idea, user_requirement=user_requirement, style=style)
 
+    @_synchronized
     def set_active(self, session_id: str) -> dict[str, Any]:
         normalized = self._normalize_session_id(session_id)
         data = self.load()
@@ -96,6 +149,7 @@ class SessionIndex:
         self.save(data)
         return dict(data["sessions"][normalized])
 
+    @_synchronized
     def update_stage(self, session_id: str, stage: str, summary: str = "") -> None:
         data = self.load()
         record = data.get("sessions", {}).get(session_id)
@@ -107,6 +161,7 @@ class SessionIndex:
         record["updated_at"] = datetime.now().isoformat(timespec="seconds")
         self.save(data)
 
+    @_synchronized
     def mark_stale(self, session_id: str, keys: list[str]) -> None:
         data = self.load()
         record = data.get("sessions", {}).get(session_id)
@@ -118,6 +173,7 @@ class SessionIndex:
         record["updated_at"] = datetime.now().isoformat(timespec="seconds")
         self.save(data)
 
+    @_synchronized
     def update_compaction(self, session_id: str, result: dict[str, Any]) -> None:
         data = self.load()
         session = data.get("sessions", {}).get(session_id)
@@ -151,6 +207,7 @@ class SessionIndex:
         record = self.get(session_id) if session_id else self.active()
         return str((record or {}).get("compacted_summary", "") or "")
 
+    @_synchronized
     def append_turn_record(self, session_id: str, record: dict[str, Any]) -> None:
         data = self.load()
         session = data.get("sessions", {}).get(session_id)

--- a/agents/screenwriter.py
+++ b/agents/screenwriter.py
@@ -1,11 +1,12 @@
 import logging
-from optparse import Option
 from typing import List, Optional
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
-from tenacity import retry, stop_after_attempt
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from utils.retry import after_func
 
 
 
@@ -136,6 +137,7 @@ class Screenwriter:
         return story
 
 
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=30), after=after_func)
     async def write_script_based_on_story(
         self,
         story: str,

--- a/agents/script_planner.py
+++ b/agents/script_planner.py
@@ -4,7 +4,9 @@ from langchain_core.output_parsers import PydanticOutputParser
 from langchain.chat_models import init_chat_model
 from pydantic import BaseModel, Field
 from typing import List, Optional, Literal
-from tenacity import retry
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from utils.retry import after_func
 
 
 narrative_script_prompt_template = \
@@ -341,7 +343,7 @@ class ScriptPlanner:
             api_key=api_key,
         )
 
-    @retry
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=30), after=after_func)
     def plan_script(
         self,
         basic_idea: str,

--- a/main_agent.py
+++ b/main_agent.py
@@ -130,8 +130,15 @@ async def amain(argv: list[str] | None = None) -> int:
             print_event({"type": "done", "turn_id": turn_id, "assistant": message, "tool_results": []}, jsonl=args.jsonl)
             print_event({"type": "session", "turn_id": turn_id, "session": runtime.session_index.snapshot()}, jsonl=args.jsonl)
             continue
-        async for event in runtime.stream_events(user_input):
-            print_event(event, jsonl=args.jsonl)
+        try:
+            async for event in runtime.stream_events(user_input):
+                print_event(event, jsonl=args.jsonl)
+        except Exception as exc:
+            # Keep the REPL alive: one failed turn must not kill the process
+            # (and with it the TUI driving us over stdio).
+            turn_id = f"turn-{uuid4().hex[:12]}"
+            print_event({"type": "error", "turn_id": turn_id, "message": f"turn failed: {exc}"}, jsonl=args.jsonl)
+            print_event({"type": "done", "turn_id": turn_id, "assistant": "", "tool_results": []}, jsonl=args.jsonl)
     return 0
 
 

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,225 @@
+"""Regression tests for error-boundary and durability fixes.
+
+Covers: LLM client retry/empty-choices handling, agent-loop turn error
+boundary, session index corruption/atomicity/concurrency, and bounded
+retry policies with backoff across agents and API clients.
+"""
+
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tenacity.stop import stop_never
+from tenacity.wait import wait_none
+
+from agent_runtime.llm import OpenAICompatibleLLM
+from agent_runtime.loop import AgentLoop
+from agent_runtime.prompts import PromptBuilder
+from agent_runtime.session_index import SessionIndex
+from agent_runtime.tool_executor import ToolExecutor
+from agent_runtime.tools import ToolRegistry
+from agents.screenwriter import Screenwriter
+from agents.script_planner import ScriptPlanner
+from tools.image_generator_doubao_seedream_yunwu_api import ImageGeneratorDoubaoSeedreamYunwuAPI
+from tools.image_generator_nanobanana_google_api import ImageGeneratorNanobananaGoogleAPI
+from tools.image_generator_nanobanana_yunwu_api import ImageGeneratorNanobananaYunwuAPI
+from tools.reranker_bge_silicon_api import RerankerBgeSiliconapi
+
+
+class FakeStatusError(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+        super().__init__(f"http status {status_code}")
+
+
+def _fake_completion(text="ok"):
+    message = MagicMock()
+    message.content = text
+    message.tool_calls = None
+    message.model_dump.return_value = {}
+    return MagicMock(choices=[MagicMock(message=message)])
+
+
+class TestLLMClient(unittest.IsolatedAsyncioTestCase):
+    def _llm(self, create):
+        llm = OpenAICompatibleLLM(model="m", base_url="http://localhost:1", api_key="k")
+        llm.client = MagicMock(chat=MagicMock(completions=MagicMock(create=create)))
+        return llm
+
+    async def test_retries_rate_limit_then_succeeds(self):
+        create = AsyncMock(side_effect=[FakeStatusError(429), _fake_completion("recovered")])
+        llm = self._llm(create)
+        result = await llm.complete([{"role": "user", "content": "x"}], tools=[])
+        self.assertEqual(result.text, "recovered")
+        self.assertEqual(create.await_count, 2)
+
+    async def test_does_not_retry_auth_errors(self):
+        create = AsyncMock(side_effect=FakeStatusError(401))
+        llm = self._llm(create)
+        with self.assertRaises(FakeStatusError):
+            await llm.complete([{"role": "user", "content": "x"}], tools=[])
+        self.assertEqual(create.await_count, 1)
+
+    async def test_gives_up_after_bounded_attempts(self):
+        create = AsyncMock(side_effect=FakeStatusError(500))
+        llm = self._llm(create)
+        with self.assertRaises(FakeStatusError):
+            await llm.complete([{"role": "user", "content": "x"}], tools=[])
+        self.assertLessEqual(create.await_count, 4)
+        self.assertGreater(create.await_count, 1)
+
+    async def test_empty_choices_raises_clear_error(self):
+        create = AsyncMock(return_value=MagicMock(choices=[]))
+        llm = self._llm(create)
+        with self.assertRaisesRegex(RuntimeError, "choice"):
+            await llm.complete([{"role": "user", "content": "x"}], tools=[])
+
+
+class BoomLLM:
+    async def complete(self, messages, tools):
+        raise RuntimeError("boom-llm")
+
+
+class TestLoopErrorBoundary(unittest.IsolatedAsyncioTestCase):
+    async def test_llm_failure_emits_error_and_persists_failed_turn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            index = SessionIndex(tmp)
+            registry = ToolRegistry([])
+            loop = AgentLoop(index, PromptBuilder(f"{tmp}/prompts", index, registry), registry, ToolExecutor(registry, index), BoomLLM())
+            events = [event async for event in loop.stream_events("hi")]
+            kinds = [event["type"] for event in events]
+            self.assertIn("error", kinds)
+            error_event = next(event for event in events if event["type"] == "error")
+            self.assertIn("boom-llm", error_event["message"])
+            self.assertEqual(events[-2]["type"], "done")
+            self.assertEqual(events[-1]["type"], "session")
+            active = index.active()
+            records = index.get(active["session_id"])["recent_turn_records"]
+            self.assertEqual(records[-1]["status"], "failed")
+
+
+class TestSessionIndexDurability(unittest.TestCase):
+    def test_corrupt_sessions_file_is_backed_up_not_silently_replaced(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            index = SessionIndex(tmp)
+            index.create(idea="precious work", session_id="keep-me")
+            index.sessions_path.write_text("{ definitely not json", encoding="utf-8")
+            data = index.load()
+            self.assertEqual(data["sessions"], {})
+            backups = list(index.vimax_dir.glob("sessions.json.corrupt-*"))
+            self.assertEqual(len(backups), 1, "corrupt state must be preserved for recovery, not discarded")
+            self.assertIn("definitely not json", backups[0].read_text(encoding="utf-8"))
+
+    def test_save_is_atomic_and_leaves_no_temp_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            index = SessionIndex(tmp)
+            index.create(session_id="roundtrip")
+            self.assertEqual(list(index.vimax_dir.glob("*.tmp")), [])
+            self.assertIn("roundtrip", index.load()["sessions"])
+
+    def test_concurrent_creates_do_not_lose_sessions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            index_a = SessionIndex(tmp)
+            index_b = SessionIndex(tmp)
+
+            def worker(index, tag):
+                for i in range(40):
+                    index.create(session_id=f"s-{tag}-{i}")
+
+            threads = [
+                threading.Thread(target=worker, args=(index_a, "a")),
+                threading.Thread(target=worker, args=(index_b, "b")),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            sessions = index_a.load()["sessions"]
+            self.assertEqual(len(sessions), 80, "concurrent read-modify-write must not lose sessions")
+
+
+class TestBoundedRetryPolicies(unittest.TestCase):
+    CASES = [
+        ("Screenwriter.write_script_based_on_story", Screenwriter.write_script_based_on_story),
+        ("ScriptPlanner.plan_script", ScriptPlanner.plan_script),
+        ("RerankerBgeSiliconapi.__call__", RerankerBgeSiliconapi.__call__),
+        ("ImageGeneratorDoubaoSeedreamYunwuAPI.generate_single_image", ImageGeneratorDoubaoSeedreamYunwuAPI.generate_single_image),
+        ("ImageGeneratorNanobananaGoogleAPI.generate_single_image", ImageGeneratorNanobananaGoogleAPI.generate_single_image),
+        ("ImageGeneratorNanobananaYunwuAPI.generate_single_image", ImageGeneratorNanobananaYunwuAPI.generate_single_image),
+    ]
+
+    def test_every_retry_is_bounded_with_backoff(self):
+        for name, fn in self.CASES:
+            with self.subTest(name=name):
+                retrying = getattr(fn, "retry", None)
+                self.assertIsNotNone(retrying, f"{name} must have a retry policy")
+                self.assertIsNot(retrying.stop, stop_never, f"{name} must not retry forever")
+                self.assertNotIsInstance(retrying.wait, wait_none, f"{name} must back off between attempts")
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self.payload
+
+
+class _FakeSession:
+    def __init__(self, scripted):
+        self.scripted = list(scripted)
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def _next(self):
+        response = self.scripted[min(self.calls, len(self.scripted) - 1)]
+        self.calls += 1
+        return _FakeResponse(*response)
+
+    def post(self, url, **kwargs):
+        return self._next()
+
+    def get(self, url, **kwargs):
+        return self._next()
+
+
+class TestClientHttpErrors(unittest.IsolatedAsyncioTestCase):
+    async def test_reranker_surfaces_http_error_without_retry(self):
+        session = _FakeSession([
+            ({"message": "invalid api key"}, 401),
+            ({"results": []}, 200),
+        ])
+        reranker = RerankerBgeSiliconapi(api_key="bad", base_url="http://x")
+        with patch("tools.reranker_bge_silicon_api.aiohttp.ClientSession", return_value=session):
+            with self.assertRaisesRegex(RuntimeError, "401"):
+                await reranker(documents=["doc"], query="q", top_n=1)
+        self.assertEqual(session.calls, 1, "4xx must fail fast with the real error, not retry into KeyError")
+
+    async def test_seedream_surfaces_http_error_without_retry(self):
+        session = _FakeSession([
+            ({"error": {"message": "invalid api key"}}, 401),
+            ({"data": [{"url": "http://img"}]}, 200),
+        ])
+        generator = ImageGeneratorDoubaoSeedreamYunwuAPI(api_key="bad")
+        with patch("tools.image_generator_doubao_seedream_yunwu_api.aiohttp.ClientSession", return_value=session):
+            with self.assertRaisesRegex(RuntimeError, "401"):
+                await generator.generate_single_image(prompt="p")
+        self.assertEqual(session.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/image_generator_doubao_seedream_yunwu_api.py
+++ b/tools/image_generator_doubao_seedream_yunwu_api.py
@@ -1,9 +1,10 @@
 # https://yunwu.apifox.cn/api-347960869
 
+import asyncio
 import logging
 import aiohttp
 from typing import List, Optional
-from tenacity import retry, stop_after_attempt
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from utils.retry import after_func
 from utils.image import image_path_to_b64
 from interfaces.image_output import ImageOutput
@@ -21,7 +22,13 @@ class ImageGeneratorDoubaoSeedreamYunwuAPI:
         self.model = model
 
 
-    @retry(stop=stop_after_attempt(3), after=after_func)
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, max=30),
+        retry=retry_if_exception_type((aiohttp.ClientError, asyncio.TimeoutError)),
+        reraise=True,
+        after=after_func,
+    )
     async def generate_single_image(
         self,
         prompt: str,
@@ -57,13 +64,11 @@ class ImageGeneratorDoubaoSeedreamYunwuAPI:
             "Content-Type": "application/json",
         }
 
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(self.base_url, json=payload, headers=headers) as response:
-                    response_json = await response.json()
-        except Exception as e:
-            logging.error(f"Error occurred while generating image: {e}")
-            raise e
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self.base_url, json=payload, headers=headers) as response:
+                response_json = await response.json()
+                if response.status >= 400:
+                    raise RuntimeError(f"Image generation failed with HTTP {response.status}: {response_json}")
 
         data = response_json['data'][0]['url']
         return ImageOutput(fmt="url", ext="png", data=data)

--- a/tools/image_generator_nanobanana_google_api.py
+++ b/tools/image_generator_nanobanana_google_api.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from google import genai
 from google.genai import types
 from google.genai.errors import ClientError
-from tenacity import retry, stop_after_attempt
+from tenacity import retry, stop_after_attempt, wait_exponential
 from interfaces.image_output import ImageOutput
 from utils.retry import after_func
 from utils.rate_limiter import RateLimiter
@@ -25,7 +25,7 @@ class ImageGeneratorNanobananaGoogleAPI:
             api_key=api_key,
         )
 
-    @retry(stop=stop_after_attempt(3), after=after_func)
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=30), after=after_func)
     async def generate_single_image(
         self,
         prompt: str,

--- a/tools/image_generator_nanobanana_yunwu_api.py
+++ b/tools/image_generator_nanobanana_yunwu_api.py
@@ -5,7 +5,7 @@ from PIL import Image
 from typing import List, Optional
 from google import genai
 from google.genai import types
-from tenacity import retry, stop_after_attempt
+from tenacity import retry, stop_after_attempt, wait_exponential
 from interfaces.image_output import ImageOutput
 from utils.retry import after_func
 
@@ -27,7 +27,7 @@ class ImageGeneratorNanobananaYunwuAPI:
         self.model = model
 
 
-    @retry(stop=stop_after_attempt(3), after=after_func)
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=30), after=after_func)
     async def generate_single_image(
         self,
         prompt: str,

--- a/tools/reranker_bge_silicon_api.py
+++ b/tools/reranker_bge_silicon_api.py
@@ -1,8 +1,7 @@
-import requests
 from typing import List
 import aiohttp
 import asyncio
-from tenacity import retry, stop_after_attempt
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 import logging
 
 
@@ -21,6 +20,9 @@ class RerankerBgeSiliconapi:
 
     @retry(
         stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, max=30),
+        retry=retry_if_exception_type((aiohttp.ClientError, asyncio.TimeoutError)),
+        reraise=True,
         after=lambda retry_state: logging.warning(f"Retrying SiliconReranker due to error: {retry_state.outcome.exception()}"),
     )
     async def __call__(
@@ -50,6 +52,8 @@ class RerankerBgeSiliconapi:
         async with aiohttp.ClientSession() as session:
             async with session.post(url, json=payload, headers=headers) as resp:
                 response = await resp.json()
+                if resp.status >= 400:
+                    raise RuntimeError(f"Rerank request failed with HTTP {resp.status}: {response}")
 
 
         """

--- a/ui/src/cli.tsx
+++ b/ui/src/cli.tsx
@@ -183,44 +183,70 @@ function App() {
   });
 
   useEffect(() => {
-    const {command, args} = agentCommand();
-    const child = spawn(command, args, {cwd: repoRoot, env: process.env});
-    childRef.current = child;
+    let unmounted = false;
+    let respawnCount = 0;
 
-    child.stdout.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => {
-      bufferRef.current += chunk;
-      const parts = bufferRef.current.split('\n');
-      bufferRef.current = parts.pop() ?? '';
-      for (const part of parts) {
-        consumeJsonLine(part);
-      }
-    });
+    function startAgent() {
+      const {command, args} = agentCommand();
+      const child = spawn(command, args, {cwd: repoRoot, env: process.env});
+      childRef.current = child;
+      bufferRef.current = '';
 
-    child.stderr.setEncoding('utf8');
-    child.stderr.on('data', (chunk: string) => {
-      for (const line of chunk.split('\n')) {
-        if (!line.trim()) continue;
-        appendLine({kind: 'terminal', text: `[stderr]: ${line}`});
-      }
-    });
+      // Without a listener, an EPIPE on stdin (child dying mid-write) is an
+      // uncaught exception that takes down the whole TUI.
+      child.stdin.on('error', (error: Error) => {
+        appendLine({kind: 'error', text: `agent stdin error: ${error.message}`});
+      });
 
-    child.on('error', (error) => {
-      appendLine({kind: 'error', text: `agent process error: ${error.message}`});
-    });
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => {
+        respawnCount = 0;
+        bufferRef.current += chunk;
+        const parts = bufferRef.current.split('\n');
+        bufferRef.current = parts.pop() ?? '';
+        for (const part of parts) {
+          consumeJsonLine(part);
+        }
+      });
 
-    child.on('exit', (code, signal) => {
-      childRef.current = null;
-      setBusy(false);
-      if (code && code !== 0) {
-        appendLine({kind: 'error', text: `agent process exited with code ${code}`});
-      } else if (signal) {
-        appendLine({kind: 'status', text: `agent process stopped by ${signal}`});
-      }
-    });
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => {
+        for (const line of chunk.split('\n')) {
+          if (!line.trim()) continue;
+          appendLine({kind: 'terminal', text: `[stderr]: ${line}`});
+        }
+      });
+
+      child.on('error', (error) => {
+        appendLine({kind: 'error', text: `agent process error: ${error.message}`});
+      });
+
+      child.on('exit', (code, signal) => {
+        childRef.current = null;
+        setBusy(false);
+        if (code && code !== 0) {
+          appendLine({kind: 'error', text: `agent process exited with code ${code}`});
+        } else if (signal) {
+          appendLine({kind: 'status', text: `agent process stopped by ${signal}`});
+        }
+        if (unmounted) return;
+        if (respawnCount >= 3) {
+          appendLine({kind: 'error', text: 'agent process keeps exiting; giving up on restarts (quit and relaunch)'});
+          return;
+        }
+        respawnCount += 1;
+        appendLine({kind: 'status', text: `restarting agent process (attempt ${respawnCount}/3)...`});
+        setTimeout(() => {
+          if (!unmounted) startAgent();
+        }, 1000);
+      });
+    }
+
+    startAgent();
 
     return () => {
-      child.kill();
+      unmounted = true;
+      childRef.current?.kill();
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Robustness fixes across the agent runtime, session persistence, and API clients:

- **Agent LLM client** (`agent_runtime/llm.py`) — had no retry, no explicit timeout, and an unguarded `choices[0]`; any transient 429/5xx propagated out of `stream_events`, killing the turn (and the REPL driving the TUI) and losing the turn record. The client now retries transient errors with backoff, fails fast on auth errors, sets an explicit request timeout, and raises a clear error on empty `choices`.
- **Turn error boundary** (`agent_runtime/loop.py`, `main_agent.py`) — LLM failures now emit an `error` event and still persist a `failed` turn record; the CLI REPL survives any turn-level exception instead of exiting with a traceback.
- **Session persistence** (`agent_runtime/session_index.py`) — `sessions.json` was written non-atomically; corruption recovery silently returned empty state and the next save destroyed every session; and every mutator was an unlocked read-modify-write that lost concurrent updates (reproduced in a test: concurrent creates lost sessions). Saves now go through temp-file + `os.replace`, corrupt files are preserved as `sessions.json.corrupt-*` backups, and mutators hold an `flock` across their read-modify-write cycle.
- **Retry policies** — `Screenwriter.write_script_based_on_story` (the first structured step of idea2video) had no retry at all; `ScriptPlanner.plan_script` used bare `@retry` (retry forever, no wait). The reranker and seedream clients never checked response status, so a 401 surfaced as `KeyError('results')` retried three times back-to-back; they now fail fast on HTTP errors with the real response body in the message and only retry network errors, with backoff. The nanobanana clients gained backoff between attempts.
- **TUI** (`ui/src/cli.tsx`) — the agent child process is now respawned when it exits (capped at 3 consecutive attempts) instead of every subsequent submit failing with "agent process is not available", and stdin has an `error` listener so an EPIPE during a write no longer crashes the whole UI.

## Test plan

`uv run --with pytest python -m pytest tests/` — 113 passed on this branch (102 existing + 11 new in `tests/test_robustness.py`), including a concurrency test that reproduces the session-loss race against the old code. The `cli.tsx` change is the one part not covered by automated tests (no test harness exists for the Ink UI); it was kept surgical for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)