### PR TITLE
Fix rate limiter lock contention, media resource leaks, and packaging/config hygiene

### DIFF
--- a/agents/camera_image_generator.py
+++ b/agents/camera_image_generator.py
@@ -188,16 +188,16 @@ class CameraImageGenerator:
         second_video_path = os.path.join(output_dir, f"{video_name}-Scene-002.mp4")
         if os.path.exists(second_video_path):
             # use first frame of second shot as new camera image
-            clip = VideoFileClip(second_video_path)
-            ff = clip.get_frame(0)
+            with VideoFileClip(second_video_path) as clip:
+                ff = clip.get_frame(0)
             ff = Image.fromarray(ff.astype('uint8'), 'RGB')
             return ImageOutput(fmt="pil", ext="png", data=ff)
         else:
             # use last frame of transition video to instead
-            clip = VideoFileClip(transition_video_path)
-            lf_time = clip.duration - (1 / clip.fps)
-            lf_time = max(0, lf_time)
-            lf = clip.get_frame(lf_time)
+            with VideoFileClip(transition_video_path) as clip:
+                lf_time = clip.duration - (1 / clip.fps)
+                lf_time = max(0, lf_time)
+                lf = clip.get_frame(lf_time)
             lf = Image.fromarray(lf.astype('uint8'), 'RGB')
             return ImageOutput(fmt="pil", ext="png", data=lf)
 

--- a/configs/idea2video_minimax.yaml
+++ b/configs/idea2video_minimax.yaml
@@ -11,7 +11,7 @@ chat_model:
   init_args:
     model: MiniMax-M3
     model_provider: minimax
-    api_key: <YOUR_MINIMAX_API_KEY>
+    api_key:  # leave empty to use the MINIMAX_API_KEY environment variable
     # base_url is auto-resolved to https://api.minimax.io/v1
   max_requests_per_minute: 500
   max_requests_per_day: 2000
@@ -19,14 +19,14 @@ chat_model:
 image_generator:
   class_path: tools.ImageGeneratorNanobananaGoogleAPI
   init_args:
-    api_key: <YOUR_API_KEY>
+    api_key:
   max_requests_per_minute: 10
   max_requests_per_day: 500
 
 video_generator:
   class_path: tools.VideoGeneratorVeoGoogleAPI
   init_args:
-    api_key: <YOUR_API_KEY>
+    api_key:
   max_requests_per_minute: 2
   max_requests_per_day: 10
 

--- a/configs/script2video_minimax.yaml
+++ b/configs/script2video_minimax.yaml
@@ -11,7 +11,7 @@ chat_model:
   init_args:
     model: MiniMax-M3
     model_provider: minimax
-    api_key: <YOUR_MINIMAX_API_KEY>
+    api_key:  # leave empty to use the MINIMAX_API_KEY environment variable
     # base_url is auto-resolved to https://api.minimax.io/v1
   max_requests_per_minute: null
   max_requests_per_day: null
@@ -19,14 +19,14 @@ chat_model:
 image_generator:
   class_path: tools.ImageGeneratorNanobananaGoogleAPI
   init_args:
-    api_key: <YOUR_API_KEY>
+    api_key:
   max_requests_per_minute: 2
   max_requests_per_day: 50
 
 video_generator:
   class_path: tools.VideoGeneratorVeoGoogleAPI
   init_args:
-    api_key: <YOUR_API_KEY>
+    api_key:
   max_requests_per_minute: 2
   max_requests_per_day: 50
 

--- a/pipelines/idea2video_pipeline.py
+++ b/pipelines/idea2video_pipeline.py
@@ -6,11 +6,11 @@ from interfaces import CharacterInScene
 from typing import List, Dict, Optional
 import asyncio
 import json
-from moviepy import VideoFileClip, concatenate_videoclips
 import yaml
 from langchain.chat_models import init_chat_model
 from tools.render_backend import RenderBackend
 from utils.provider_presets import resolve_chat_model_config
+from utils.video import concatenate_video_files
 
 
 def _pipeline_print(quiet: bool, message: str) -> None:
@@ -246,9 +246,6 @@ class Idea2VideoPipeline:
             _pipeline_print(quiet, f"🚀 Skipped concatenating videos, already exists.")
         else:
             _pipeline_print(quiet, f"🎬 Starting concatenating videos...")
-            video_clips = [VideoFileClip(final_video_path)
-                           for final_video_path in all_video_paths]
-            final_video = concatenate_videoclips(video_clips)
-            final_video.write_videofile(final_video_path)
+            concatenate_video_files(all_video_paths, final_video_path)
             _pipeline_print(quiet, f"☑️ Concatenated videos, saved to {final_video_path}.")
         return final_video_path

--- a/pipelines/script2video_pipeline.py
+++ b/pipelines/script2video_pipeline.py
@@ -5,7 +5,6 @@ import logging
 import asyncio
 import time
 from typing import Any, Callable, Optional, Dict, List, Tuple, Literal
-from moviepy import VideoFileClip, concatenate_videoclips
 from PIL import Image
 from agents import *
 import yaml
@@ -13,6 +12,7 @@ from interfaces import *
 from langchain.chat_models import init_chat_model
 from tools.render_backend import RenderBackend
 from utils.provider_presets import resolve_chat_model_config
+from utils.video import concatenate_video_files
 
 
 def _pipeline_print(quiet: bool, message: str) -> None:
@@ -259,12 +259,10 @@ class Script2VideoPipeline:
         else:
             print(f"🎬 Starting concatenating videos...")
             _emit_render_progress(progress, "concat_start", "Concatenating video clips", {"shot_count": len(shot_descriptions)})
-            video_clips = [
-                VideoFileClip(os.path.join(self.working_dir, "shots", f"{shot_description.idx}", "video.mp4"))
-                for shot_description in shot_descriptions
-            ]
-            final_video = concatenate_videoclips(video_clips)
-            final_video.write_videofile(final_video_path, codec="libx264", preset="medium")
+            concatenate_video_files(
+                [os.path.join(self.working_dir, "shots", f"{shot_description.idx}", "video.mp4") for shot_description in shot_descriptions],
+                final_video_path,
+            )
             print(f"☑️ Concatenated videos, saved to {final_video_path}.")
             _emit_render_progress(progress, "concat_done", "Final video concatenated", {"path": final_video_path})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "autolongvideogeneration"
 version = "1.1.0"
 description = "Add your description here"
-readme = "README.md"
+readme = "readme.md"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",
@@ -37,6 +37,7 @@ name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
-[[index]]
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-default = true
+[dependency-groups]
+dev = [
+    "pytest>=8",
+]

--- a/tests/test_hygiene_guards.py
+++ b/tests/test_hygiene_guards.py
@@ -1,0 +1,117 @@
+"""Regression tests for rate-limiter lock behavior, media resource cleanup,
+packaging metadata, config templates, and test-suite isolation."""
+
+import asyncio
+import subprocess
+import sys
+import tomllib
+import unittest
+from contextlib import suppress
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from utils.rate_limiter import RateLimiter
+from utils.video import concatenate_video_files
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestRateLimiterLocking(unittest.IsolatedAsyncioTestCase):
+    async def test_waiting_acquirer_does_not_hold_the_lock(self):
+        limiter = RateLimiter(max_requests_per_minute=1)
+        await limiter.acquire()  # consume the only slot in the window
+        waiter = asyncio.create_task(limiter.acquire())
+        await asyncio.sleep(0.05)  # waiter is now waiting for the window to free
+        try:
+            try:
+                await asyncio.wait_for(limiter.lock.acquire(), timeout=0.25)
+                limiter.lock.release()
+            except asyncio.TimeoutError:
+                self.fail("rate limiter sleeps while holding its lock, blocking every other caller")
+        finally:
+            waiter.cancel()
+            with suppress(asyncio.CancelledError):
+                await waiter
+
+    async def test_min_delay_smoothing_still_applies(self):
+        limiter = RateLimiter(max_requests_per_minute=600)  # min delay 0.1s
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await limiter.acquire()
+        await limiter.acquire()
+        self.assertGreaterEqual(loop.time() - start, 0.08)
+
+
+class TestVideoConcatenationCleanup(unittest.TestCase):
+    def test_concatenate_closes_all_clips_even_on_failure(self):
+        clips = [MagicMock(), MagicMock()]
+        final = MagicMock()
+        with patch("utils.video.VideoFileClip", side_effect=clips), \
+             patch("utils.video.concatenate_videoclips", return_value=final):
+            concatenate_video_files(["a.mp4", "b.mp4"], "out.mp4")
+        final.write_videofile.assert_called_once()
+        final.close.assert_called_once()
+        for clip in clips:
+            clip.close.assert_called_once()
+
+        # And when writing fails, the ffmpeg readers must still be released.
+        clips = [MagicMock(), MagicMock()]
+        final = MagicMock()
+        final.write_videofile.side_effect = OSError("disk full")
+        with patch("utils.video.VideoFileClip", side_effect=clips), \
+             patch("utils.video.concatenate_videoclips", return_value=final):
+            with self.assertRaises(OSError):
+                concatenate_video_files(["a.mp4", "b.mp4"], "out.mp4")
+        final.close.assert_called_once()
+        for clip in clips:
+            clip.close.assert_called_once()
+
+
+class TestPackagingMetadata(unittest.TestCase):
+    def test_pyproject_is_consistent(self):
+        with open(REPO_ROOT / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        readme = data["project"]["readme"]
+        self.assertTrue((REPO_ROOT / readme).exists(), f"readme points at missing file: {readme}")
+        self.assertNotIn("index", data, "top-level [[index]] is not valid pyproject TOML and is silently ignored")
+        dev_group = data.get("dependency-groups", {}).get("dev", [])
+        self.assertTrue(any("pytest" in str(item) for item in dev_group), "pytest must be a declared dev dependency so the suite runs from the venv")
+
+
+class TestProviderConfigTemplates(unittest.TestCase):
+    def test_minimax_templates_do_not_ship_truthy_placeholders(self):
+        for name in ("idea2video_minimax.yaml", "script2video_minimax.yaml"):
+            with open(REPO_ROOT / "configs" / name, encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+            chat_key = config["chat_model"]["init_args"].get("api_key")
+            self.assertFalse(chat_key, f"{name}: a truthy api_key placeholder defeats the MINIMAX_API_KEY env fallback")
+            for section in ("image_generator", "video_generator"):
+                key = config[section]["init_args"].get("api_key")
+                self.assertNotIn("<", str(key or ""), f"{name}: {section} ships an angle-bracket placeholder that would be sent as a bearer token")
+
+
+class TestSuiteIsolation(unittest.TestCase):
+    def test_importing_minimax_tests_does_not_stub_global_modules(self):
+        code = (
+            "import sys; import tests.test_minimax_integration; "
+            "mod = sys.modules.get('cv2'); "
+            "from unittest.mock import MagicMock; "
+            "exit(1 if isinstance(mod, MagicMock) else 0)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            "importing tests.test_minimax_integration replaces sys.modules entries at import time, "
+            "making every later-collected test module see MagicMock stubs instead of real libraries",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -4,8 +4,9 @@ These tests verify provider preset resolution and default pipeline config
 loading. They mock the LangChain factory so no real API calls are made.
 
 Heavy multimedia dependencies (moviepy, scenedetect, cv2, google-genai,
-etc.) are stubbed at the module level so the pipeline modules can be
-imported in a lightweight test environment.
+etc.) are stubbed in setUpModule and restored in tearDownModule. Stubbing
+at import time leaked the MagicMocks into sys.modules for every test module
+collected after this one, making suite results import-order dependent.
 """
 
 import importlib
@@ -15,7 +16,6 @@ import types
 import unittest
 from unittest.mock import patch, MagicMock
 
-# ---- stub heavy deps before any project imports ----
 _STUB_MODULES = [
     "moviepy", "cv2", "scenedetect", "scenedetect.detectors",
     "PIL", "PIL.Image",
@@ -25,13 +25,36 @@ _STUB_MODULES = [
     "langchain_community.vectorstores.FAISS",
 ]
 _saved = {}
-for _mod in _STUB_MODULES:
-    _saved[_mod] = sys.modules.get(_mod)
-    mock = MagicMock()
-    # Give stub a __spec__ so importlib.util.find_spec() works
-    mock.__spec__ = importlib.machinery.ModuleSpec(_mod, None)
-    mock.__path__ = []
-    sys.modules[_mod] = mock
+_modules_before_stubs = set()
+
+
+def setUpModule():
+    _modules_before_stubs.update(sys.modules)
+    for _mod in _STUB_MODULES:
+        _saved[_mod] = sys.modules.get(_mod)
+        mock = MagicMock()
+        # Give stub a __spec__ so importlib.util.find_spec() works
+        mock.__spec__ = importlib.machinery.ModuleSpec(_mod, None)
+        mock.__path__ = []
+        sys.modules[_mod] = mock
+
+
+def tearDownModule():
+    # Drop project modules that were first imported while the stubs were
+    # active, so later test modules import them fresh against real libraries.
+    for name in list(sys.modules):
+        if name in _modules_before_stubs:
+            continue
+        if name.split(".")[0] in {"pipelines", "agents", "tools", "interfaces"}:
+            del sys.modules[name]
+    for _mod, original in _saved.items():
+        if original is None:
+            sys.modules.pop(_mod, None)
+        else:
+            sys.modules[_mod] = original
+    _saved.clear()
+    _modules_before_stubs.clear()
+
 
 from utils.provider_presets import resolve_chat_model_config
 

--- a/tools/image_generator_nanobanana_google_api.py
+++ b/tools/image_generator_nanobanana_google_api.py
@@ -50,26 +50,30 @@ class ImageGeneratorNanobananaGoogleAPI:
         max_retries = 3
         retry_delay = 5
 
-        for attempt in range(max_retries):
-            try:
-                response = await self.client.aio.models.generate_content(
-                    model=self.model,
-                    contents=reference_images + [prompt],
-                    config=types.GenerateContentConfig(
-                        response_modalities=["IMAGE"],
-                        image_config=types.ImageConfig(
-                            aspect_ratio=aspect_ratio,
+        try:
+            for attempt in range(max_retries):
+                try:
+                    response = await self.client.aio.models.generate_content(
+                        model=self.model,
+                        contents=reference_images + [prompt],
+                        config=types.GenerateContentConfig(
+                            response_modalities=["IMAGE"],
+                            image_config=types.ImageConfig(
+                                aspect_ratio=aspect_ratio,
+                            ),
                         ),
-                    ),
-                )
-                break
-            except ClientError as e:
-                if e.status_code == 429 and attempt < max_retries - 1:
-                    wait_time = retry_delay * (2 ** attempt)
-                    logging.warning(f"Rate limit hit (429), retrying in {wait_time}s... (attempt {attempt + 1}/{max_retries})")
-                    await asyncio.sleep(wait_time)
-                else:
-                    raise
+                    )
+                    break
+                except ClientError as e:
+                    if e.status_code == 429 and attempt < max_retries - 1:
+                        wait_time = retry_delay * (2 ** attempt)
+                        logging.warning(f"Rate limit hit (429), retrying in {wait_time}s... (attempt {attempt + 1}/{max_retries})")
+                        await asyncio.sleep(wait_time)
+                    else:
+                        raise
+        finally:
+            for reference_image in reference_images:
+                reference_image.close()
 
         image = None
         text = ""

--- a/tools/image_generator_nanobanana_yunwu_api.py
+++ b/tools/image_generator_nanobanana_yunwu_api.py
@@ -43,16 +43,20 @@ class ImageGeneratorNanobananaYunwuAPI:
 
         reference_images = [Image.open(path) for path in reference_image_paths]
 
-        response = await self.client.aio.models.generate_content(
-            model=self.model,
-            contents=reference_images + [prompt],
-            config=types.GenerateContentConfig(
-                response_modalities=["TEXT", "IMAGE"],
-                image_config=types.ImageConfig(
-                    aspect_ratio=aspect_ratio,
+        try:
+            response = await self.client.aio.models.generate_content(
+                model=self.model,
+                contents=reference_images + [prompt],
+                config=types.GenerateContentConfig(
+                    response_modalities=["TEXT", "IMAGE"],
+                    image_config=types.ImageConfig(
+                        aspect_ratio=aspect_ratio,
+                    ),
                 ),
-            ),
-        )
+            )
+        finally:
+            for reference_image in reference_images:
+                reference_image.close()
 
         image = None
         text = ""

--- a/utils/rate_limiter.py
+++ b/utils/rate_limiter.py
@@ -41,65 +41,54 @@ class RateLimiter:
         Acquire permission to make a request.
 
         This method will block until it's safe to make a request according to the rate limits.
+
+        The lock is only held while checking and recording, never while sleeping:
+        a caller waiting out a window (up to 24h for the daily limit) must not
+        block every other caller's check. After each sleep the limits are
+        re-checked, since another caller may have taken the freed slot.
         """
         if not self.max_requests_per_minute and not self.max_requests_per_day:
             # Rate limiting is disabled
             return
 
-        async with self.lock:
-            current_time = time.time()
+        while True:
+            message = None
+            async with self.lock:
+                current_time = time.time()
 
-            # Clean up old request times (keep requests from last 24 hours for daily limit)
-            if self.max_requests_per_day:
-                self.request_times = [t for t in self.request_times if current_time - t < 86400]
-            elif self.max_requests_per_minute:
-                self.request_times = [t for t in self.request_times if current_time - t < 60]
+                # Clean up old request times (keep requests from last 24 hours for daily limit)
+                if self.max_requests_per_day:
+                    self.request_times = [t for t in self.request_times if current_time - t < 86400]
+                elif self.max_requests_per_minute:
+                    self.request_times = [t for t in self.request_times if current_time - t < 60]
 
-            # Check daily limit first
-            if self.max_requests_per_day and self.max_requests_per_day > 0:
-                daily_requests = [t for t in self.request_times if current_time - t < 86400]
+                wait_time = 0.0
 
-                if len(daily_requests) >= self.max_requests_per_day:
-                    oldest_request = daily_requests[0]
-                    wait_time = 86400 - (current_time - oldest_request)
-
-                    if wait_time > 0:
+                # Check daily limit first
+                if self.max_requests_per_day and self.max_requests_per_day > 0:
+                    daily_requests = [t for t in self.request_times if current_time - t < 86400]
+                    if len(daily_requests) >= self.max_requests_per_day:
+                        wait_time = 86400 - (current_time - daily_requests[0])
                         hours = wait_time / 3600
-                        print(f"Daily rate limit reached ({self.max_requests_per_day} requests/day). Waiting {hours:.1f} hours...")
-                        await asyncio.sleep(wait_time)
-                        current_time = time.time()
+                        message = f"Daily rate limit reached ({self.max_requests_per_day} requests/day). Waiting {hours:.1f} hours..."
 
-                        # Clean up after waiting
-                        self.request_times = [t for t in self.request_times if current_time - t < 86400]
+                # Check per-minute limit
+                if wait_time <= 0 and self.max_requests_per_minute and self.max_requests_per_minute > 0:
+                    minute_requests = [t for t in self.request_times if current_time - t < 60]
+                    if len(minute_requests) >= self.max_requests_per_minute:
+                        wait_time = 60 - (current_time - minute_requests[0])
+                        message = f"Rate limit reached ({self.max_requests_per_minute} requests/min). Waiting {wait_time:.1f}s..."
+                    elif self.request_times and self.min_delay > 0:
+                        # Also ensure minimum delay between consecutive requests
+                        time_since_last = current_time - self.request_times[-1]
+                        if time_since_last < self.min_delay:
+                            wait_time = self.min_delay - time_since_last
 
-            # Check per-minute limit
-            if self.max_requests_per_minute and self.max_requests_per_minute > 0:
-                minute_requests = [t for t in self.request_times if current_time - t < 60]
+                if wait_time <= 0:
+                    # Record this request
+                    self.request_times.append(current_time)
+                    return
 
-                if len(minute_requests) >= self.max_requests_per_minute:
-                    oldest_request = minute_requests[0]
-                    wait_time = 60 - (current_time - oldest_request)
-
-                    if wait_time > 0:
-                        print(f"Rate limit reached ({self.max_requests_per_minute} requests/min). Waiting {wait_time:.1f}s...")
-                        await asyncio.sleep(wait_time)
-                        current_time = time.time()
-
-                        # Clean up old request times again after waiting
-                        if self.max_requests_per_day:
-                            self.request_times = [t for t in self.request_times if current_time - t < 86400]
-                        else:
-                            self.request_times = [t for t in self.request_times if current_time - t < 60]
-
-                # Also ensure minimum delay between consecutive requests
-                if self.request_times and self.min_delay > 0:
-                    last_request = self.request_times[-1]
-                    time_since_last = current_time - last_request
-
-                    if time_since_last < self.min_delay:
-                        wait_time = self.min_delay - time_since_last
-                        await asyncio.sleep(wait_time)
-                        current_time = time.time()
-
-            # Record this request
-            self.request_times.append(current_time)
+            if message:
+                print(message)
+            await asyncio.sleep(wait_time)

--- a/utils/video.py
+++ b/utils/video.py
@@ -1,6 +1,7 @@
 import logging
 import requests
 from tenacity import retry
+from moviepy import VideoFileClip, concatenate_videoclips
 
 
 @retry
@@ -20,3 +21,24 @@ def download_video(url, save_path):
     except Exception as e:
         logging.error(f"Error downloading video: {e}")
         raise e
+
+
+def concatenate_video_files(video_paths, output_path, codec="libx264", preset="medium"):
+    """Concatenate video files, releasing every ffmpeg reader even on failure.
+
+    Each VideoFileClip keeps an ffmpeg subprocess and file handle open until
+    closed; leaking them exhausts file descriptors on long multi-scene runs.
+    """
+    clips = []
+    final = None
+    try:
+        for path in video_paths:
+            clips.append(VideoFileClip(path))
+        final = concatenate_videoclips(clips)
+        final.write_videofile(output_path, codec=codec, preset=preset)
+    finally:
+        if final is not None:
+            final.close()
+        for clip in clips:
+            clip.close()
+    return output_path

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,11 @@ dependencies = [
     { name = "tenacity" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.14" },
@@ -155,6 +160,9 @@ requires-dist = [
     { name = "scenedetect", extras = ["opencv"], specifier = ">=0.6.7.1" },
     { name = "tenacity", specifier = ">=9.1.2" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
 
 [[package]]
 name = "cachetools"
@@ -550,6 +558,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
     { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
     { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1023,6 +1040,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "proglog"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1190,6 +1216,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]

--- a/vimax
+++ b/vimax
@@ -75,7 +75,7 @@ case "$command" in
       echo "error: ui dependencies are missing. Run: cd $ROOT/ui && npm install" >&2
       exit 2
     fi
-    exec "$ROOT/ui/node_modules/.bin/tsx" "$ROOT/ui/src/cli.tsx" "${tui_args[@]}"
+    exec "$ROOT/ui/node_modules/.bin/tsx" "$ROOT/ui/src/cli.tsx" ${tui_args[@]+"${tui_args[@]}"}
     ;;
   --help|-h|help)
     usage


### PR DESCRIPTION
## Summary

- **`utils/rate_limiter.py`** — `acquire()` slept while holding its lock, so one caller waiting out a window (up to 24 hours for the daily limit) blocked every other caller from even checking. Waits are now computed under the lock but slept outside it, with limits re-checked after waking.
- **Media resource leaks** — video concatenation in both pipelines created one `VideoFileClip` (ffmpeg subprocess + file handle) per shot and never closed any of them; long multi-scene runs exhaust file descriptors. Extracted `utils.video.concatenate_video_files`, which releases every reader even when writing fails, and switched both call sites. `get_new_camera_image` and the nanobanana clients now close their `VideoFileClip`/PIL handles as well.
- **`pyproject.toml`** — `readme` pointed at `README.md` but the file on disk is `readme.md`, which fails any metadata build on a case-sensitive filesystem; the top-level `[[index]]` table is not valid pyproject TOML and was silently ignored; and pytest was not a declared dependency, so `python -m pytest` failed from the project venv. Fixed path, removed the dead block, added a `[dependency-groups] dev` with pytest (lockfile updated).
- **MiniMax config templates** shipped truthy `<YOUR_MINIMAX_API_KEY>` placeholders — the chat-model one defeated the documented `MINIMAX_API_KEY` env fallback in `resolve_chat_model_config` and was sent verbatim as a bearer token, producing a confusing 401. Templates now ship empty keys with a comment.
- **`tests/test_minimax_integration.py`** installed MagicMock stubs into `sys.modules` at import time and never restored them, so every test module collected afterwards saw stubs instead of real libraries (import-order-dependent results). Stubs now install in `setUpModule` and `tearDownModule` fully restores them, including project modules first imported under the stubs.
- **`vimax` launcher** — `"${tui_args[@]}"` on an empty array under `set -u` aborts with "unbound variable" on bash < 4.4 (macOS ships 3.2). Now guarded with `${tui_args[@]+...}`.

## Test plan

`uv run python -m pytest tests/` — 108 passed on this branch (102 existing + 6 new in `tests/test_hygiene_guards.py`), now runnable without `--with pytest` thanks to the dev group. New tests cover the lock-free wait, concatenation cleanup on success and failure, packaging metadata consistency, template key falsiness, and test-suite isolation (subprocess check that importing the minimax test module no longer mutates `sys.modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)