### PR TITLE
Accept **kwargs in all video generators per the VideoGenerator protocol

### DIFF
--- a/tests/test_generator_protocol.py
+++ b/tests/test_generator_protocol.py
@@ -1,0 +1,37 @@
+"""Every video generator must satisfy the VideoGenerator protocol, which
+declares **kwargs: pipelines pass progress= callbacks, and generators that
+reject unknown kwargs crash mid-render (TypeError) on the transition path."""
+
+import inspect
+import unittest
+
+from tools.video_generator_doubao_seedance_yunwu_api import VideoGeneratorDoubaoSeedanceYunwuAPI
+from tools.video_generator_omni_yunwu_api import VideoGeneratorOmniYunwuAPI
+from tools.video_generator_openrouter_api import VideoGeneratorOpenRouterAPI
+from tools.video_generator_veo_google_api import VideoGeneratorVeoGoogleAPI
+from tools.video_generator_veo_yunwu_api import VideoGeneratorVeoYunwuAPI
+
+
+class TestVideoGeneratorProtocol(unittest.TestCase):
+    GENERATORS = [
+        VideoGeneratorDoubaoSeedanceYunwuAPI,
+        VideoGeneratorOmniYunwuAPI,
+        VideoGeneratorOpenRouterAPI,
+        VideoGeneratorVeoGoogleAPI,
+        VideoGeneratorVeoYunwuAPI,
+    ]
+
+    def test_generate_single_video_accepts_arbitrary_kwargs(self):
+        for cls in self.GENERATORS:
+            with self.subTest(cls=cls.__name__):
+                params = inspect.signature(cls.generate_single_video).parameters
+                accepts_var_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+                self.assertTrue(
+                    accepts_var_kwargs,
+                    f"{cls.__name__}.generate_single_video must accept **kwargs per tools.protocols.VideoGenerator "
+                    "(pipelines pass progress=...)",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/video_generator_doubao_seedance_yunwu_api.py
+++ b/tools/video_generator_doubao_seedance_yunwu_api.py
@@ -158,6 +158,7 @@ class VideoGeneratorDoubaoSeedanceYunwuAPI:
         aspect_ratio: str = "16:9",
         fps: Literal[16, 24] = 16,
         duration: Literal[5, 10] = 5,
+        **kwargs,
     ) -> VideoOutput:
         """
         Generate a single video by creating a task and waiting for completion.

--- a/tools/video_generator_veo_google_api.py
+++ b/tools/video_generator_veo_google_api.py
@@ -36,6 +36,7 @@ class VideoGeneratorVeoGoogleAPI:
         resolution: str = "1080p",
         aspect_ratio: str = "16:9",
         duration: int = 8,
+        **kwargs,
     ) -> VideoOutput:
 
         params = {


### PR DESCRIPTION
## Summary

`tools/protocols.py` declares `generate_single_video(self, prompt, reference_image_paths, **kwargs)`, and both pipeline call sites (`script2video_pipeline.py` and `camera_image_generator.generate_transition_video`) pass a `progress=` callback. Two generators declared fixed signatures instead — `VideoGeneratorVeoGoogleAPI` and `VideoGeneratorDoubaoSeedanceYunwuAPI` — so any render configured with them crashes mid-run:

```
TypeError: VideoGeneratorVeoGoogleAPI.generate_single_video() got an unexpected keyword argument 'progress'
```

First reproduced on the transition-video path of a real idea2video run (Google Veo backend). The other three generators (openrouter, veo_yunwu, omni) already comply.

## Fix

Add `**kwargs` to the two non-compliant signatures, plus a protocol-conformance test (`tests/test_generator_protocol.py`) that asserts all five video generators accept arbitrary keyword arguments, so a future generator can't regress this.

## Test plan

`uv run --with pytest python -m pytest tests/` — all passing including the new conformance test (red before the fix for exactly the two generators above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)